### PR TITLE
edit workflows to also make arm binaries

### DIFF
--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -56,6 +56,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -82,9 +88,9 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-

--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -15,6 +15,17 @@ on:
       - 'uv.lock'
       - '.github/workflows/build-push-backend.yml'
       - 'tests/**'
+  pull_request:
+    paths:
+      - 'media_manager/**'
+      - 'alembic/**'
+      - 'alembic.ini'
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/build-push-backend.yml'
+      - 'tests/**'
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-push-frontend.yml
+++ b/.github/workflows/build-push-frontend.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           context: ./web
           file: ./web/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-push-frontend.yml
+++ b/.github/workflows/build-push-frontend.yml
@@ -9,6 +9,11 @@ on:
     paths:
       - 'web/**'
       - '.github/workflows/build-push-frontend.yml'
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/build-push-frontend.yml'
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-push-frontend.yml
+++ b/.github/workflows/build-push-frontend.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -64,6 +70,7 @@ jobs:
         with:
           context: ./web
           file: ./web/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-push-metadata_relay.yml
+++ b/.github/workflows/build-push-metadata_relay.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - 'metadata_relay/**'
       - '.github/workflows/python-lint_metadata_relay.yaml'
+  pull_request:
+    paths:
+      - 'metadata_relay/**'
+      - '.github/workflows/python-lint_metadata_relay.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-push-metadata_relay.yml
+++ b/.github/workflows/build-push-metadata_relay.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           context: ./metadata_relay
           file: ./metadata_relay/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-push-metadata_relay.yml
+++ b/.github/workflows/build-push-metadata_relay.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -59,6 +65,7 @@ jobs:
         with:
           context: ./metadata_relay
           file: ./metadata_relay/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to enable multi-platform Docker image builds for the backend, frontend, and metadata relay services.