### PR TITLE
Hotfix: fix downloads from Sabnzbd being in the wrong folders

### DIFF
--- a/media_manager/torrent/download_clients/sabnzbd.py
+++ b/media_manager/torrent/download_clients/sabnzbd.py
@@ -52,7 +52,9 @@ class SabnzbdDownloadClient(AbstractDownloadClient):
 
         try:
             # Add NZB to SABnzbd queue
-            response = self.client.add_uri(url=str(indexer_result.download_url))
+            response = self.client.add_uri(
+                url=str(indexer_result.download_url), nzbname=indexer_result.title
+            )
             if not response["status"]:
                 error_msg = response
                 log.error(f"Failed to add NZB to SABnzbd: {error_msg}")


### PR DESCRIPTION
Sabnzbd used the default folder names for downloaded nzb's, though MM expects other specific folder names which causes the import of the files to fail because no files are found