### PR TITLE
Fix: Session cookie not being transmitted when using http

### DIFF
--- a/media_manager/auth/users.py
+++ b/media_manager/auth/users.py
@@ -119,7 +119,9 @@ bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
 cookie_transport = CookieTransport(
     cookie_max_age=LIFETIME, cookie_samesite="lax", cookie_secure=False
 )
-openid_cookie_transport = RedirectingCookieTransport(cookie_max_age=LIFETIME)
+openid_cookie_transport = RedirectingCookieTransport(
+    cookie_max_age=LIFETIME, cookie_samesite="lax", cookie_secure=False
+)
 
 bearer_auth_backend = AuthenticationBackend(
     name="jwt",

--- a/media_manager/auth/users.py
+++ b/media_manager/auth/users.py
@@ -116,7 +116,9 @@ class RedirectingCookieTransport(CookieTransport):
 
 
 bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
-cookie_transport = CookieTransport(cookie_max_age=LIFETIME)
+cookie_transport = CookieTransport(
+    cookie_max_age=LIFETIME, cookie_samesite="lax", cookie_secure=False
+)
 openid_cookie_transport = RedirectingCookieTransport(cookie_max_age=LIFETIME)
 
 bearer_auth_backend = AuthenticationBackend(


### PR DESCRIPTION
FastApi Users sets the `Secure` flag on cookies by default to true, which causes the session cookie to not be transmitted when using http (which you probably shouldn't anyways), and thus the user can't login.

this fixes
#55 