### PR TITLE
Remove db port exposure from the docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ docker compose up -d
   <img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" >
 </a>
 
-
 ## Check out the awesome sponsors of MediaManager ❤️
+
 <a href="https://fosstodon.org/@aljazmerzen"><img src="https://github.com/aljazerzen.png" width="80px" alt="Aljaž Mur Eržen" /></a>&nbsp;&nbsp;
 <a href="https://github.com/ldrrp"><img src="https://github.com/ldrrp.png" width="80px" alt="Luis Rodriguez" /></a>&nbsp;&nbsp;
 
 
 <!-- ROADMAP -->
+
 ## Roadmap
 
 - [x] support for more torrent indexers
@@ -95,7 +96,6 @@ See the [open issues](hhttps://maxdorninger.github.io/MediaManager/issues) for a
 ![Screenshot 2025-07-02 174416](https://github.com/user-attachments/assets/0d50f53b-64da-4243-8408-1d6fc85fe81b)
 ![Screenshot 2025-06-28 222908](https://github.com/user-attachments/assets/193e1afd-dabb-42a2-ab28-59f2784371c7)
 
-
 ## Developer Quick Start
 
 ```bash
@@ -104,8 +104,9 @@ See the [open issues](hhttps://maxdorninger.github.io/MediaManager/issues) for a
   # Activate the virtual environment
   uv pip install -e .
 ```
+
 ```bash
-docker compose up db -d
+docker compose -f docker-compose.yaml -f docker-compose.dev.yaml up db -d
 ```
 
 ```bash
@@ -115,26 +116,28 @@ uv run alembic upgrade head
 ### Get the frontend up and running
 
 ```bash
-cd /web && npm install
+cd ./web && npm install
 ```
 
 ### Now start the backend and frontend
+
 ```bash
-fastapi dev /media_manager/main.py --reload --host
+fastapi dev ./media_manager/main.py --reload --host
 ```
 
 ```bash
-cd /web && npm run dev
+cd ./web && npm run dev
 ```
-
 
 <!-- LICENSE -->
+
 ## License
 
 Distributed under the AGPL 3.0. See `LICENSE.txt` for more information.
 
 
 <!-- ACKNOWLEDGMENTS -->
+
 ## Acknowledgments
 
 * [Thanks to Pawel Czerwinski for the image on the login screen](https://unsplash.com/@pawel_czerwinski)

--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,7 @@ name = "Documentary"
 path = "/data/movies/documentary"
 
 [database]
-host = "localhost"
+host = "db"
 port = 5432
 user = "MediaManager"
 password = "MediaManager"

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,4 @@
+services:
+  db:
+    ports:
+      - "5432:5432"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,15 +14,11 @@ services:
     volumes:
       - ./postgres:/var/lib/postgresql/data
     healthcheck:
-       test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
-       interval: 10s
-       timeout: 5s
-       retries: 5
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     environment:
       POSTGRES_USER: MediaManager
       POSTGRES_DB: MediaManager
       POSTGRES_PASSWORD: MediaManager
-    ports:
-      - "5432:5432"
-
-


### PR DESCRIPTION
This PR moves the db port exposure in the docker-compose.yml file to a seperate file. The port binding is not needed when running this as an app, only when developing.



Offtopic: I've not been able to get the development environment working, I'm not a Python developer but I was eager to try this app when I saw the 1.7.0 update on Reddit, saw these things and decided to send in this PR.

When trying to run the app itself through the installation guide (wget, wget, docker compose up -d) I also don't get the app working (#66). I also think the app binds to the wrong ports. The config.toml makes it bind to port 3000 internally, but the docker-compose.yaml binds to 8000. But that's for another PR/Issue.

Thank you for you work!