### PR TITLE
Fix some qBitorrent bugs and make Sabnzbd api path configurable

### DIFF
--- a/Writerside/topics/download-client-configuration.md
+++ b/Writerside/topics/download-client-configuration.md
@@ -84,6 +84,10 @@ Port of the SABnzbd API. Default is `8080`.
 
 API key for SABnzbd. You can find this in SABnzbd's configuration under "General" → "API Key".
 
+- `base_path`
+
+API base path for SABnzbd. It usually ends with `/api`, the default is `/api`.
+
 ## Example Configuration
 
 Here's a complete example of the download clients section in your `config.toml`:

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -111,6 +111,7 @@ enabled = false
 host = "http://localhost"
 port = 8080
 api_key = ""
+base_path = "/api"
 
 [indexers]
 # Prowlarr settings

--- a/config.example.toml
+++ b/config.example.toml
@@ -111,6 +111,7 @@ enabled = false
 host = "http://localhost"
 port = 8080
 api_key = ""
+base_path = "/api"
 
 [indexers]
 # Prowlarr settings

--- a/media_manager/torrent/config.py
+++ b/media_manager/torrent/config.py
@@ -30,6 +30,7 @@ class SabnzbdConfig(BaseSettings):
     port: int = 8080
     api_key: str = ""
     enabled: bool = False
+    base_path: str = "/api"
 
 
 class TorrentConfig(BaseSettings):

--- a/media_manager/torrent/download_clients/qbittorrent.py
+++ b/media_manager/torrent/download_clients/qbittorrent.py
@@ -29,6 +29,10 @@ class QbittorrentDownloadClient(AbstractDownloadClient):
         "checkingDL",
         "forcedDL",
         "moving",
+        "stoppedDL",
+        "forcedMetaDL",
+        "metaDL",
+        "moving",
     )
     FINISHED_STATE = (
         "uploading",
@@ -37,6 +41,7 @@ class QbittorrentDownloadClient(AbstractDownloadClient):
         "stalledUP",
         "checkingUP",
         "forcedUP",
+        "stoppedUP",
     )
     ERROR_STATE = ("missingFiles", "error", "checkingResumeData")
     UNKNOWN_STATE = ("unknown",)

--- a/media_manager/torrent/download_clients/qbittorrent.py
+++ b/media_manager/torrent/download_clients/qbittorrent.py
@@ -55,8 +55,6 @@ class QbittorrentDownloadClient(AbstractDownloadClient):
         except Exception as e:
             log.error(f"Failed to log into qbittorrent: {e}")
             raise
-        finally:
-            self.api_client.auth_log_out()
 
         try:
             log.info("Trying to create MediaManager category in qBittorrent")
@@ -70,12 +68,22 @@ class QbittorrentDownloadClient(AbstractDownloadClient):
             log.info(
                 "MediaManager category already exists in qBittorrent, modifying existing category to reflect current config."
             )
-            self.api_client.torrents_edit_category(
-                name=self.config.category_name,
-                save_path=self.config.category_save_path
-                if self.config.category_save_path != ""
-                else None,
-            )
+            try:
+                self.api_client.torrents_edit_category(
+                    name=self.config.category_name,
+                    save_path=self.config.category_save_path
+                    if self.config.category_save_path != ""
+                    else None,
+                )
+            except Exception as e:
+                if str(e) == "":
+                    log.info(
+                        "MediaManager category in qBittorrent is already up to date"
+                    )
+                else:
+                    log.error(
+                        f"Error on updating MediaManager category in qBittorrent, error: {e}"
+                    )
 
     def download_torrent(self, indexer_result: IndexerQueryResult) -> Torrent:
         """

--- a/media_manager/torrent/download_clients/qbittorrent.py
+++ b/media_manager/torrent/download_clients/qbittorrent.py
@@ -32,7 +32,6 @@ class QbittorrentDownloadClient(AbstractDownloadClient):
         "stoppedDL",
         "forcedMetaDL",
         "metaDL",
-        "moving",
     )
     FINISHED_STATE = (
         "uploading",

--- a/media_manager/torrent/download_clients/sabnzbd.py
+++ b/media_manager/torrent/download_clients/sabnzbd.py
@@ -33,7 +33,7 @@ class SabnzbdDownloadClient(AbstractDownloadClient):
             port=str(self.config.port),
             api_key=self.config.api_key,
         )
-        self.client._base_url = f"{self.config.host.rstrip('/')}:{self.config.port}/api"  # the library expects a /sabnzbd prefix for whatever reason
+        self.client._base_url = f"{self.config.host.rstrip('/')}:{self.config.port}{self.config.base_path}"  # the library expects a /sabnzbd prefix for whatever reason
         try:
             # Test connection
             version = self.client.version()

--- a/media_manager/torrent/utils.py
+++ b/media_manager/torrent/utils.py
@@ -61,6 +61,8 @@ def import_file(target_file: Path, source_file: Path):
         target_file.unlink()
     try:
         target_file.hardlink_to(source_file)
+    except FileExistsError:
+        log.error(f"File already exists at {target_file}. ")
     except OSError as e:
         log.error(
             f"Failed to create hardlink from {source_file} to {target_file}: {e}. "


### PR DESCRIPTION
This pull request introduces several updates to improve configuration flexibility and enhance error handling in the codebase. The most significant changes include adding a `base_path` configuration option for SABnzbd, expanding the state handling in the qBittorrent client, and improving error handling during qBittorrent category updates.

### Configuration Updates:
* Added a `base_path` configuration option for SABnzbd

### qBittorrent Client Enhancements:
* Added new torrent states (`stoppedDL`, `forcedMetaDL`, `metaDL`, `stoppedUP`) to the qBittorrent client to improve state tracking. (`media_manager/torrent/download_clients/qbittorrent.py`: [[1]](diffhunk://#diff-48bec81890fefee1b14eb75794e56bc883fafc34468c50b7e1c603aed5ee1230R32-R35) [[2]](diffhunk://#diff-48bec81890fefee1b14eb75794e56bc883fafc34468c50b7e1c603aed5ee1230R44)
* Improved error handling during qBittorrent category updates, including logging specific errors and handling cases where the category is already up to date. (`media_manager/torrent/download_clients/qbittorrent.py`: [media_manager/torrent/download_clients/qbittorrent.pyR76-R91](diffhunk://#diff-48bec81890fefee1b14eb75794e56bc883fafc34468c50b7e1c603aed5ee1230R76-R91))

### Code Cleanup:
* Removed unnecessary API logout calls in the qBittorrent client initialization to streamline the code. (`media_manager/torrent/download_clients/qbittorrent.py`: [media_manager/torrent/download_clients/qbittorrent.pyL58-L59](diffhunk://#diff-48bec81890fefee1b14eb75794e56bc883fafc34468c50b7e1c603aed5ee1230L58-L59))


This PR fixes #104, #103, #95. 