### PR TITLE
add support for magnet urls to indexers

### DIFF
--- a/media_manager/indexer/indexers/jackett.py
+++ b/media_manager/indexer/indexers/jackett.py
@@ -3,7 +3,6 @@ import xml.etree.ElementTree as ET
 from xml.etree.ElementTree import Element
 
 import requests
-from pydantic import HttpUrl
 
 from media_manager.indexer.indexers.generic import GenericIndexer
 from media_manager.indexer.schemas import IndexerQueryResult
@@ -75,7 +74,7 @@ class Jackett(GenericIndexer):
 
                     result = IndexerQueryResult(
                         title=item.find("title").text,
-                        download_url=HttpUrl(item.find("enclosure").attrib["url"]),
+                        download_url=str(item.find("enclosure").attrib["url"]),
                         seeders=seeders,
                         flags=flags,
                         size=int(item.find("size").text),

--- a/media_manager/indexer/indexers/prowlarr.py
+++ b/media_manager/indexer/indexers/prowlarr.py
@@ -43,7 +43,7 @@ class Prowlarr(GenericIndexer):
                     result_list.append(
                         IndexerQueryResult(
                             download_url=result["downloadUrl"]
-                            if result["downloadUrl"] is not None
+                            if "downloadUrl" in result
                             else result["magnetUrl"],
                             title=result["sortTitle"],
                             seeders=result["seeders"],

--- a/media_manager/indexer/indexers/prowlarr.py
+++ b/media_manager/indexer/indexers/prowlarr.py
@@ -42,7 +42,9 @@ class Prowlarr(GenericIndexer):
                 if is_torrent:
                     result_list.append(
                         IndexerQueryResult(
-                            download_url=result["downloadUrl"],
+                            download_url=result["downloadUrl"]
+                            if result["downloadUrl"] is not None
+                            else result["magnetUrl"],
                             title=result["sortTitle"],
                             seeders=result["seeders"],
                             flags=result["indexerFlags"],

--- a/media_manager/indexer/schemas.py
+++ b/media_manager/indexer/schemas.py
@@ -3,7 +3,7 @@ import typing
 from uuid import UUID, uuid4
 
 import pydantic
-from pydantic import BaseModel, computed_field, ConfigDict, HttpUrl
+from pydantic import BaseModel, computed_field, ConfigDict
 
 from media_manager.torrent.models import Quality
 
@@ -15,7 +15,9 @@ class IndexerQueryResult(BaseModel):
 
     id: IndexerQueryResultId = pydantic.Field(default_factory=uuid4)
     title: str
-    download_url: HttpUrl
+    download_url: (
+        str  # this can be a magnet link or a download URL to the .torrent file
+    )
     seeders: int
     flags: list[str]
     size: int

--- a/tests/indexer/test_service.py
+++ b/tests/indexer/test_service.py
@@ -1,7 +1,6 @@
 import uuid
 from unittest.mock import MagicMock, patch
 import pytest
-from pydantic import HttpUrl
 
 from media_manager.indexer.schemas import IndexerQueryResult, IndexerQueryResultId
 from media_manager.indexer.repository import IndexerRepository
@@ -18,7 +17,7 @@ class DummyIndexer(GenericIndexer):
             IndexerQueryResult(
                 id=IndexerQueryResultId(uuid.uuid4()),
                 title=f"{query} S01 1080p",
-                download_url=HttpUrl("https://example.com/torrent1"),
+                download_url="https://example.com/torrent1",
                 seeders=10,
                 flags=["test"],
                 size=123456,
@@ -62,7 +61,7 @@ def test_get_result_returns_result(mock_indexer_repository):
     expected_result = IndexerQueryResult(
         id=result_id,
         title="Test S01 1080p",
-        download_url=HttpUrl("https://example.com/torrent2"),
+        download_url="https://example.com/torrent2",
         seeders=10,
         flags=["test"],
         size=123456,


### PR DESCRIPTION
This PR changes the download_url's type from HttpUrl to str. It also makes prowlarr fallback to the magnetUrl field if the downloadUrl field doesn't exist when processing IndexerQuerySearchResults.

It fixes #69.