### PR TITLE
make prowlarr follow redirects for every url

### DIFF
--- a/media_manager/indexer/utils.py
+++ b/media_manager/indexer/utils.py
@@ -151,10 +151,9 @@ def follow_redirects_to_final_torrent_url(initial_url: str) -> str | None:
     except requests.exceptions.RequestException as e:
         log.error(f"An error occurred during the request: {e}")
         raise RuntimeError(f"An error occurred during the request: {e}")
-
-    if final_url is None:
-        log.error("Final URL could not be determined. Returning None.")
-        return None
+    if not final_url:
+        log.error("Final URL could not be determined.")
+        raise RuntimeError("Final URL could not be determined.")
     if final_url.startswith("http://") or final_url.startswith("https://"):
         log.info("Final URL protocol: HTTP/HTTPS")
     elif final_url.startswith("magnet:"):

--- a/media_manager/indexer/utils.py
+++ b/media_manager/indexer/utils.py
@@ -138,10 +138,10 @@ def follow_redirects_to_final_torrent_url(initial_url: str) -> str | None:
                     break
                 else:
                     log.error(
-                        f"Reached unexpected non-HTTP/HTTPS/magnet URL: {final_url}"
+                        f"Reached unexpected non-HTTP/HTTPS/magnet URL: {redirect_url}"
                     )
                     raise RuntimeError(
-                        f"Reached unexpected non-HTTP/HTTPS/magnet URL: {final_url}"
+                        f"Reached unexpected non-HTTP/HTTPS/magnet URL: {redirect_url}"
                     )
             else:
                 # Not a redirect, so the current URL is the final one

--- a/media_manager/indexer/utils.py
+++ b/media_manager/indexer/utils.py
@@ -152,6 +152,9 @@ def follow_redirects_to_final_torrent_url(initial_url: str) -> str | None:
         log.error(f"An error occurred during the request: {e}")
         raise RuntimeError(f"An error occurred during the request: {e}")
 
+    if final_url is None:
+        log.error("Final URL could not be determined. Returning None.")
+        return None
     if final_url.startswith("http://") or final_url.startswith("https://"):
         log.info("Final URL protocol: HTTP/HTTPS")
     elif final_url.startswith("magnet:"):

--- a/media_manager/indexer/utils.py
+++ b/media_manager/indexer/utils.py
@@ -1,5 +1,7 @@
 import logging
 
+import requests
+
 from media_manager.config import AllEncompassingConfig
 from media_manager.indexer.config import ScoringRuleSet
 from media_manager.indexer.schemas import IndexerQueryResult
@@ -107,3 +109,57 @@ def evaluate_indexer_query_results(
     query_results = [result for result in query_results if result.score >= 0]
     query_results.sort(reverse=True)
     return query_results
+
+
+def follow_redirects_to_final_torrent_url(initial_url: str) -> str | None:
+    """
+    Follows redirects to get the final torrent URL.
+    :param initial_url: The initial URL to follow.
+    :return: The final torrent URL or None if it fails.
+    """
+    current_url = initial_url
+    final_url = None
+    try:
+        while True:
+            response = requests.get(current_url, allow_redirects=False)
+
+            if 300 <= response.status_code < 400:
+                redirect_url = response.headers.get("Location")
+                if redirect_url.startswith("http://") or redirect_url.startswith(
+                    "https://"
+                ):
+                    # It's an HTTP/HTTPS redirect, continue following
+                    current_url = redirect_url
+                    log.info(f"Following HTTP/HTTPS redirect to: {current_url}")
+                elif redirect_url.startswith("magnet:"):
+                    # It's a Magnet URL, this is our final destination
+                    final_url = redirect_url
+                    log.info(f"Reached Magnet URL: {final_url}")
+                    break
+                else:
+                    log.error(
+                        f"Reached unexpected non-HTTP/HTTPS/magnet URL: {final_url}"
+                    )
+                    raise RuntimeError(
+                        f"Reached unexpected non-HTTP/HTTPS/magnet URL: {final_url}"
+                    )
+            else:
+                # Not a redirect, so the current URL is the final one
+                final_url = current_url
+                log.info(f"Reached final (non-redirect) URL: {final_url}")
+                break
+    except requests.exceptions.RequestException as e:
+        log.error(f"An error occurred during the request: {e}")
+        raise RuntimeError(f"An error occurred during the request: {e}")
+
+    if final_url.startswith("http://") or final_url.startswith("https://"):
+        log.info("Final URL protocol: HTTP/HTTPS")
+    elif final_url.startswith("magnet:"):
+        log.info("Final URL protocol: Magnet")
+    else:
+        log.error(f"Final URL is not a valid HTTP/HTTPS or Magnet URL: {final_url}")
+        raise RuntimeError(
+            f"Final URL is not a valid HTTP/HTTPS or Magnet URL: {final_url}"
+        )
+
+    return final_url


### PR DESCRIPTION
This pull request enhances the `Prowlarr` indexer by improving URL handling for torrent downloads and introduces a utility function to follow redirects to the final torrent URL. The most important changes include adding logic to handle multiple URL fallback options, implementing a new utility function to resolve redirects, and updating the `Prowlarr` search logic to integrate these improvements.

### Enhancements to URL handling in the `Prowlarr` indexer:

* Updated the `search` method in `prowlarr.py` to handle multiple fallback options for determining the download URL (`downloadUrl`, `magnetUrl`, or `guid`) and added logging for each case.
* Integrated the newly introduced `follow_redirects_to_final_torrent_url` utility function to resolve redirects for non-magnet URLs, with error handling and fallback to the initial URL in case of failures.

### New utility function for URL redirection:

* Added `follow_redirects_to_final_torrent_url` in `utils.py`, which follows HTTP/HTTPS redirects to determine the final torrent URL, and handles magnet URLs as the final destination. Includes extensive logging and error handling for unexpected cases.
* Imported the `requests` library and the new utility function in `prowlarr.py` to support the redirection logic. [[1]](diffhunk://#diff-e583054d8f77939385693afb6da8f59e096f7663d35a81a0296a580c8f46d2a2R8) [[2]](diffhunk://#diff-68360a387d2c28fc49ac14495b9bdd800f040fd087fe450472e4a379e4031768R3-R4)