### PR TITLE
Remove certain special chars from file names

### DIFF
--- a/media_manager/movies/service.py
+++ b/media_manager/movies/service.py
@@ -32,7 +32,11 @@ from media_manager.movies.repository import MovieRepository
 from media_manager.exceptions import NotFoundError
 import pprint
 from media_manager.torrent.repository import TorrentRepository
-from media_manager.torrent.utils import import_file, import_torrent
+from media_manager.torrent.utils import (
+    import_file,
+    import_torrent,
+    remove_special_characters,
+)
 from media_manager.indexer.service import IndexerService
 from media_manager.metadataProvider.abstractMetaDataProvider import (
     AbstractMetadataProvider,
@@ -473,7 +477,10 @@ class MovieService:
 
         movie_file_path = (
             misc_config.movie_directory
-            / f"{movie.name} ({movie.year})  [{movie.metadata_provider}id-{movie.external_id}]"
+            / f"{remove_special_characters(movie.name)} ({movie.year})  [{movie.metadata_provider}id-{movie.external_id}]"
+        )
+        log.debug(
+            f"Movie {movie.name} without special characters: {remove_special_characters(movie.name)}"
         )
         if movie.library != "Default":
             for library in misc_config.movie_libraries:
@@ -481,7 +488,7 @@ class MovieService:
                     log.debug(f"Using library {library.name} for movie {movie.name}")
                     movie_file_path = (
                         Path(library.path)
-                        / f"{movie.name} ({movie.year})  [{movie.metadata_provider}id-{movie.external_id}]"
+                        / f"{remove_special_characters(movie.name)} ({movie.year})  [{movie.metadata_provider}id-{movie.external_id}]"
                     )
                     break
             else:
@@ -502,7 +509,7 @@ class MovieService:
             except Exception as e:
                 log.warning(f"Could not create path {movie_file_path}: {e}")
 
-            movie_file_name = f"{movie.name} ({movie.year})"
+            movie_file_name = f"{remove_special_characters(movie.name)} ({movie.year})"
             if movie_file.file_path_suffix != "":
                 movie_file_name += f" - {movie_file.file_path_suffix}"
 

--- a/media_manager/torrent/utils.py
+++ b/media_manager/torrent/utils.py
@@ -162,4 +162,10 @@ def remove_special_characters(filename: str) -> str:
     :param filename: The original filename.
     :return: A sanitized version of the filename.
     """
-    return re.sub(r"([<>:\"/\\|?*])", "", filename)
+    # Remove invalid characters
+    sanitized = re.sub(r"([<>:\"/\\|?*])", "", filename)
+    
+    # Remove leading and trailing dots or spaces
+    sanitized = sanitized.strip(" .")
+    
+    return sanitized

--- a/media_manager/torrent/utils.py
+++ b/media_manager/torrent/utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import mimetypes
+import re
 from pathlib import Path
 import shutil
 
@@ -152,3 +153,13 @@ def get_torrent_hash(torrent: IndexerQueryResult) -> str:
             log.error(f"Failed to decode torrent file: {e}")
             raise
     return torrent_hash
+
+
+def remove_special_characters(filename: str) -> str:
+    """
+    Removes special characters from the filename to ensure it works with Jellyfin.
+
+    :param filename: The original filename.
+    :return: A sanitized version of the filename.
+    """
+    return re.sub(r"([<>:\"/\\|?*])", "", filename)


### PR DESCRIPTION
This pull request introduces a new utility function, `remove_special_characters`, to sanitize file and directory names by removing special characters. The changes ensure compatibility with systems like Jellyfin and apply this sanitization across movie and TV show imports. 

### New utility function:
* Added `remove_special_characters` to `media_manager/torrent/utils.py` to strip special characters from filenames using a regex. This function ensures compatibility with Jellyfin and similar systems.

It fixes #118 .