### PR TITLE
Fix regex for importing episodes

### DIFF
--- a/media_manager/movies/service.py
+++ b/media_manager/movies/service.py
@@ -524,7 +524,7 @@ class MovieService:
             # import subtitles
             for subtitle_file in subtitle_files:
                 language_code_match = re.search(
-                    r"\.([a-z]{2})\.srt$", subtitle_file.name, re.IGNORECASE
+                    r"[. ]([a-z]{2})[. ]srt$", subtitle_file.name, re.IGNORECASE
                 )
                 if not language_code_match:
                     log.warning(

--- a/media_manager/movies/service.py
+++ b/media_manager/movies/service.py
@@ -524,7 +524,7 @@ class MovieService:
             # import subtitles
             for subtitle_file in subtitle_files:
                 language_code_match = re.search(
-                    r"[. ]([a-z]{2})[. ]srt$", subtitle_file.name, re.IGNORECASE
+                    r"[. ]([a-z]{2})\.srt$", subtitle_file.name, re.IGNORECASE
                 )
                 if not language_code_match:
                     log.warning(

--- a/media_manager/torrent/utils.py
+++ b/media_manager/torrent/utils.py
@@ -164,8 +164,8 @@ def remove_special_characters(filename: str) -> str:
     """
     # Remove invalid characters
     sanitized = re.sub(r"([<>:\"/\\|?*])", "", filename)
-    
+
     # Remove leading and trailing dots or spaces
     sanitized = sanitized.strip(" .")
-    
+
     return sanitized

--- a/media_manager/tv/service.py
+++ b/media_manager/tv/service.py
@@ -553,13 +553,13 @@ class TvService:
                 if season_file.file_path_suffix != "":
                     episode_file_name += f" - {season_file.file_path_suffix}"
                 pattern = (
-                    r".*[.]S0?"
+                    r".*[. ]S0?"
                     + str(season.number)
                     + r"E0?"
                     + str(episode.number)
-                    + r"[.].*"
+                    + r"[. ].*"
                 )
-                subtitle_pattern = pattern + r"[.]([A-Za-z]{2})[.]srt"
+                subtitle_pattern = pattern + r"[. ]([A-Za-z]{2})[. ]srt"
                 target_file_name = season_path / episode_file_name
 
                 # import subtitles


### PR DESCRIPTION
This pull request makes a small but significant change to the `import_torrent_files` method in `media_manager/movies/service.py`. The change updates the regular expression used to match subtitle file names, making it more flexible in recognizing language codes.

* [`media_manager/movies/service.py`](diffhunk://#diff-57cfa309860beba31573487107eba3f7ef8ef60429c48c02fb262b9f4ff9b8d3L527-R527): Updated the regular expression in `import_torrent_files` to match language codes in subtitle file names that are separated by either a dot (`.`) or a space (` `), instead of only a dot.

It fixes #124.