### PR TITLE
Enhance frontend

### DIFF
--- a/media_manager/movies/schemas.py
+++ b/media_manager/movies/schemas.py
@@ -38,10 +38,6 @@ class PublicMovieFile(MovieFile):
     downloaded: bool = False
 
 
-class PublicMovie(Movie):
-    downloaded: bool = False
-
-
 class MovieRequestBase(BaseModel):
     min_quality: Quality
     wanted_quality: Quality
@@ -85,6 +81,11 @@ class MovieTorrent(BaseModel):
     imported: bool
     file_path_suffix: str
     usenet: bool
+
+
+class PublicMovie(Movie):
+    downloaded: bool = False
+    torrents: list[MovieTorrent] = []
 
 
 class RichMovieTorrent(BaseModel):

--- a/media_manager/movies/service.py
+++ b/media_manager/movies/service.py
@@ -259,8 +259,10 @@ class MovieService:
         :return: A public movie.
         """
         movie = self.movie_repository.get_movie_by_id(movie_id=movie_id)
+        torrents = self.get_torrents_for_movie(movie=movie).torrents
         public_movie = PublicMovie.model_validate(movie)
         public_movie.downloaded = self.is_movie_downloaded(movie_id=movie.id)
+        public_movie.torrents = torrents
         return public_movie
 
     def get_movie_by_id(self, movie_id: MovieId) -> Movie:

--- a/media_manager/tv/schemas.py
+++ b/media_manager/tv/schemas.py
@@ -163,5 +163,6 @@ class PublicShow(BaseModel):
 
     ended: bool = False
     continuous_download: bool = False
+    library: str
 
     seasons: list[PublicSeason]

--- a/web/src/lib/components/library-combobox.svelte
+++ b/web/src/lib/components/library-combobox.svelte
@@ -97,7 +97,7 @@
 				role="combobox"
 				aria-expanded={open}
 			>
-				{selectedLabel || 'Select Library'}
+				{'Select Library'}
 				<ChevronsUpDownIcon class="opacity-50" />
 			</Button>
 		{/snippet}

--- a/web/src/lib/components/torrent-table.svelte
+++ b/web/src/lib/components/torrent-table.svelte
@@ -28,7 +28,7 @@
 		{#each torrents as torrent}
 			<Table.Row>
 				<Table.Cell class="font-medium">
-					{isShow ? torrent.torrent_title : torrent.title}
+					{torrent.torrent_title}
 				</Table.Cell>
 				{#if isShow}
 					<Table.Cell>

--- a/web/src/lib/components/ui/switch/index.ts
+++ b/web/src/lib/components/ui/switch/index.ts
@@ -1,0 +1,7 @@
+import Root from './switch.svelte';
+
+export {
+	Root,
+	//
+	Root as Switch
+};

--- a/web/src/lib/components/ui/switch/switch.svelte
+++ b/web/src/lib/components/ui/switch/switch.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Switch as SwitchPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> = $props();
+</script>
+
+<SwitchPrimitive.Root
+	bind:ref
+	bind:checked
+	class={cn(
+		'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+		className
+	)}
+	{...restProps}
+>
+	<SwitchPrimitive.Thumb
+		class={cn(
+			'pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
+		)}
+	/>
+</SwitchPrimitive.Root>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -149,6 +149,7 @@ export interface PublicMovie {
 	id: string; // type: string, format: uuid
 	downloaded: boolean;
 	library: string;
+	torrents: Torrent[];
 }
 
 export interface Torrent {

--- a/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
@@ -14,6 +14,7 @@
 	import LibraryCombobox from '$lib/components/library-combobox.svelte';
 	import { Label } from '$lib/components/ui/label';
 	import { base } from '$app/paths';
+	import { Switch } from '$lib/components/ui/switch/index.js';
 
 	let movie: PublicMovie = page.data.movie;
 	let user: () => User = getContext('user');
@@ -57,7 +58,7 @@
 <h1 class="scroll-m-20 text-center text-4xl font-extrabold tracking-tight lg:text-5xl">
 	{getFullyQualifiedMediaName(movie)}
 </h1>
-<div class="flex w-full flex-1 flex-col gap-4 p-4">
+<div class="mx-auto flex w-full flex-1 flex-col gap-4 p-4 md:max-w-[80em]">
 	<div class="flex flex-col gap-4 md:flex-row md:items-stretch">
 		<div class="w-full overflow-hidden rounded-xl bg-muted/50 md:w-1/3 md:max-w-sm">
 			{#if movie.id}
@@ -75,24 +76,16 @@
 				{movie.overview}
 			</p>
 		</div>
-		<div class="w-full flex-auto rounded-xl bg-muted/50 p-4 md:w-1/3">
+		<div
+			class="flex w-full flex-auto flex-col items-center justify-start gap-2 rounded-xl bg-muted/50 p-4 md:w-1/3 md:max-w-[40em]"
+		>
 			{#if user().is_superuser}
-				<div class="mx-1 my-2 block">
-					<LibraryCombobox media={movie} mediaType="movie" />
-					<Label for="library-combobox">Select Library for this movie</Label>
-					<hr />
-				</div>
+				<LibraryCombobox media={movie} mediaType="movie" />
 				<DownloadMovieDialog {movie} />
-				<div class="my-4"></div>
 			{/if}
 			<RequestMovieDialog {movie} />
 		</div>
 	</div>
-	<!-- 	<div class="flex-1 rounded-xl bg-muted/50 p-4">
-            <div class="w-full overflow-x-auto">
-
-            </div>
-        </div> -->
 	<div class="flex-1 rounded-xl bg-muted/50 p-4">
 		<div class="w-full overflow-x-auto">
 			<TorrentTable isShow={false} torrents={movie.torrents} />

--- a/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
@@ -12,12 +12,8 @@
 	import DownloadMovieDialog from '$lib/components/download-movie-dialog.svelte';
 	import RequestMovieDialog from '$lib/components/request-movie-dialog.svelte';
 	import LibraryCombobox from '$lib/components/library-combobox.svelte';
-	import { Label } from '$lib/components/ui/label';
 	import { base } from '$app/paths';
-	import { Switch } from '$lib/components/ui/switch/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
-	import RequestSeasonDialog from "$lib/components/request-season-dialog.svelte";
-	import DownloadSeasonDialog from "$lib/components/download-season-dialog.svelte";
 
 	let movie: PublicMovie = page.data.movie;
 	let user: () => User = getContext('user');
@@ -74,29 +70,36 @@
 				</div>
 			{/if}
 		</div>
-		<div class="w-full flex-auto rounded-xl bg-muted/50 p-4 md:w-1/4">
-			<p class="leading-7 [&:not(:first-child)]:mt-6">
-				{movie.overview}
-			</p>
+		<div class="h-full w-full flex-auto rounded-xl md:w-1/4">
+			<Card.Root class="h-full w-full">
+				<Card.Header>
+					<Card.Title>Overview</Card.Title>
+				</Card.Header>
+				<Card.Content>
+					<p class="leading-7 [&:not(:first-child)]:mt-6">
+						{movie.overview}
+					</p>
+				</Card.Content>
+			</Card.Root>
 		</div>
 		<div
-			class="flex w-full flex-auto flex-col items-center justify-start gap-2 rounded-xl bg-muted/50 p-4 md:w-1/3 md:max-w-[40em]"
+			class="flex h-full w-full flex-auto flex-col items-center justify-start gap-4 rounded-xl md:w-1/3 md:max-w-[40em]"
 		>
 			{#if user().is_superuser}
-				<Card.Root class="w-full">
+				<Card.Root class="w-full  flex-1">
 					<Card.Header>
 						<Card.Title>Administrator Controls</Card.Title>
 					</Card.Header>
-					<Card.Content class="flex flex-col gap-4 items-center">
+					<Card.Content class="flex flex-col items-center gap-4">
 						<LibraryCombobox media={movie} mediaType="movie" />
 					</Card.Content>
 				</Card.Root>
 			{/if}
-			<Card.Root class="w-full">
+			<Card.Root class="w-full  flex-1">
 				<Card.Header>
 					<Card.Title>Download Options</Card.Title>
 				</Card.Header>
-				<Card.Content class="flex flex-col gap-4 items-center">
+				<Card.Content class="flex flex-col items-center gap-4">
 					{#if user().is_superuser}
 						<DownloadMovieDialog {movie} />
 					{/if}
@@ -105,9 +108,15 @@
 			</Card.Root>
 		</div>
 	</div>
-	<div class="flex-1 rounded-xl bg-muted/50 p-4">
-		<div class="w-full overflow-x-auto">
-			<TorrentTable isShow={false} torrents={movie.torrents} />
-		</div>
+	<div class="flex-1 rounded-xl">
+		<Card.Root class="h-full w-full">
+			<Card.Header>
+				<Card.Title>Torrent Information</Card.Title>
+				<Card.Description>A list of all torrents associated with this movie.</Card.Description>
+			</Card.Header>
+			<Card.Content class="flex flex-col gap-4">
+				<TorrentTable isShow={false} torrents={movie.torrents} />
+			</Card.Content>
+		</Card.Root>
 	</div>
 </div>

--- a/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
@@ -15,6 +15,9 @@
 	import { Label } from '$lib/components/ui/label';
 	import { base } from '$app/paths';
 	import { Switch } from '$lib/components/ui/switch/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import RequestSeasonDialog from "$lib/components/request-season-dialog.svelte";
+	import DownloadSeasonDialog from "$lib/components/download-season-dialog.svelte";
 
 	let movie: PublicMovie = page.data.movie;
 	let user: () => User = getContext('user');
@@ -80,10 +83,26 @@
 			class="flex w-full flex-auto flex-col items-center justify-start gap-2 rounded-xl bg-muted/50 p-4 md:w-1/3 md:max-w-[40em]"
 		>
 			{#if user().is_superuser}
-				<LibraryCombobox media={movie} mediaType="movie" />
-				<DownloadMovieDialog {movie} />
+				<Card.Root class="w-full">
+					<Card.Header>
+						<Card.Title>Administrator Controls</Card.Title>
+					</Card.Header>
+					<Card.Content class="flex flex-col gap-4 items-center">
+						<LibraryCombobox media={movie} mediaType="movie" />
+					</Card.Content>
+				</Card.Root>
 			{/if}
-			<RequestMovieDialog {movie} />
+			<Card.Root class="w-full">
+				<Card.Header>
+					<Card.Title>Download Options</Card.Title>
+				</Card.Header>
+				<Card.Content class="flex flex-col gap-4 items-center">
+					{#if user().is_superuser}
+						<DownloadMovieDialog {movie} />
+					{/if}
+					<RequestMovieDialog {movie} />
+				</Card.Content>
+			</Card.Root>
 		</div>
 	</div>
 	<div class="flex-1 rounded-xl bg-muted/50 p-4">

--- a/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
@@ -4,7 +4,7 @@
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
 	import { ImageOff } from 'lucide-svelte';
 	import { getContext } from 'svelte';
-	import type { PublicMovie, RichShowTorrent, User } from '$lib/types.js';
+	import type { PublicMovie, User } from '$lib/types.js';
 	import { getFullyQualifiedMediaName } from '$lib/utils';
 	import { page } from '$app/state';
 	import TorrentTable from '$lib/components/torrent-table.svelte';
@@ -17,7 +17,6 @@
 
 	let movie: PublicMovie = page.data.movie;
 	let user: () => User = getContext('user');
-	let torrents: RichShowTorrent = page.data.torrents;
 </script>
 
 <svelte:head>
@@ -96,7 +95,7 @@
         </div> -->
 	<div class="flex-1 rounded-xl bg-muted/50 p-4">
 		<div class="w-full overflow-x-auto">
-			<TorrentTable isShow={false} torrents={torrents.torrents} />
+			<TorrentTable isShow={false} torrents={movie.torrents} />
 		</div>
 	</div>
 </div>

--- a/web/src/routes/dashboard/movies/[movieId=uuid]/+page.ts
+++ b/web/src/routes/dashboard/movies/[movieId=uuid]/+page.ts
@@ -8,5 +8,6 @@ export const load: PageLoad = async ({ params, fetch }) => {
 	});
 	if (!res.ok) throw error(res.status, `Failed to load movie`);
 	const movieData = await res.json();
-	return { movie: movieData, torrents: [] };
+	console.log('got movie data', movieData);
+	return { movie: movieData };
 };

--- a/web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte
@@ -1,194 +1,215 @@
 <script lang="ts">
-    import {env} from '$env/dynamic/public';
-    import {Separator} from '$lib/components/ui/separator/index.js';
-    import * as Sidebar from '$lib/components/ui/sidebar/index.js';
-    import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
-    import {goto} from '$app/navigation';
-    import {ImageOff} from 'lucide-svelte';
-    import * as Table from '$lib/components/ui/table/index.js';
-    import {getContext, onMount} from 'svelte';
-    import type {PublicShow, RichShowTorrent, User} from '$lib/types.js';
-    import {getFullyQualifiedMediaName} from '$lib/utils';
-    import DownloadSeasonDialog from '$lib/components/download-season-dialog.svelte';
-    import CheckmarkX from '$lib/components/checkmark-x.svelte';
-    import {page} from '$app/state';
-    import TorrentTable from '$lib/components/torrent-table.svelte';
-    import RequestSeasonDialog from '$lib/components/request-season-dialog.svelte';
-    import MediaPicture from '$lib/components/media-picture.svelte';
-    import {Checkbox} from '$lib/components/ui/checkbox/index.js';
-    import {Switch} from '$lib/components/ui/switch/index.js';
-    import {toast} from 'svelte-sonner';
-    import {Label} from '$lib/components/ui/label';
-    import LibraryCombobox from '$lib/components/library-combobox.svelte';
-    import * as Card from '$lib/components/ui/card/index.js';
+	import { env } from '$env/dynamic/public';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
+	import { goto } from '$app/navigation';
+	import { ImageOff } from 'lucide-svelte';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { getContext } from 'svelte';
+	import type { PublicShow, RichShowTorrent, User } from '$lib/types.js';
+	import { getFullyQualifiedMediaName } from '$lib/utils';
+	import DownloadSeasonDialog from '$lib/components/download-season-dialog.svelte';
+	import CheckmarkX from '$lib/components/checkmark-x.svelte';
+	import { page } from '$app/state';
+	import TorrentTable from '$lib/components/torrent-table.svelte';
+	import RequestSeasonDialog from '$lib/components/request-season-dialog.svelte';
+	import MediaPicture from '$lib/components/media-picture.svelte';
+	import { Switch } from '$lib/components/ui/switch/index.js';
+	import { toast } from 'svelte-sonner';
+	import { Label } from '$lib/components/ui/label';
+	import LibraryCombobox from '$lib/components/library-combobox.svelte';
+	import * as Card from '$lib/components/ui/card/index.js';
 
-    const apiUrl = env.PUBLIC_API_URL;
-    let show: () => PublicShow = getContext('show');
-    let user: () => User = getContext('user');
-    let torrents: RichShowTorrent = page.data.torrentsData;
-    import {base} from '$app/paths';
+	const apiUrl = env.PUBLIC_API_URL;
+	let show: () => PublicShow = getContext('show');
+	let user: () => User = getContext('user');
+	let torrents: RichShowTorrent = page.data.torrentsData;
+	import { base } from '$app/paths';
 
-    let continuousDownloadEnabled = $state(show().continuous_download);
+	let continuousDownloadEnabled = $state(show().continuous_download);
 
-    async function toggle_continuous_download() {
-        const urlString = `${apiUrl}/tv/shows/${show().id}/continuousDownload?continuous_download=${!continuousDownloadEnabled}`;
-        console.log(
-            'Toggling continuous download for show',
-            show().name,
-            'to',
-            !continuousDownloadEnabled
-        );
-        const response = await fetch(urlString, {
-            method: 'POST',
-            credentials: 'include'
-        });
-        if (!response.ok) {
-            const errorText = await response.text();
-            toast.error('Failed to toggle continuous download: ' + errorText);
-        } else {
-            continuousDownloadEnabled = !continuousDownloadEnabled;
-            toast.success('Continuous download toggled successfully.');
-        }
-    }
+	async function toggle_continuous_download() {
+		const urlString = `${apiUrl}/tv/shows/${show().id}/continuousDownload?continuous_download=${!continuousDownloadEnabled}`;
+		console.log(
+			'Toggling continuous download for show',
+			show().name,
+			'to',
+			!continuousDownloadEnabled
+		);
+		const response = await fetch(urlString, {
+			method: 'POST',
+			credentials: 'include'
+		});
+		if (!response.ok) {
+			const errorText = await response.text();
+			toast.error('Failed to toggle continuous download: ' + errorText);
+		} else {
+			continuousDownloadEnabled = !continuousDownloadEnabled;
+			toast.success('Continuous download toggled successfully.');
+		}
+	}
 
-    /*	$effect(()=>{
+	/*	$effect(()=>{
         continuousDownloadEnabled;
         toggle_continuous_download();
     });*/
 </script>
 
 <svelte:head>
-    <title>{getFullyQualifiedMediaName(show())} - MediaManager</title>
-    <meta
-            content="View details and manage downloads for {getFullyQualifiedMediaName(
+	<title>{getFullyQualifiedMediaName(show())} - MediaManager</title>
+	<meta
+		content="View details and manage downloads for {getFullyQualifiedMediaName(
 			show()
 		)} in MediaManager"
-            name="description"
-    />
+		name="description"
+	/>
 </svelte:head>
 
 <header class="flex h-16 shrink-0 items-center gap-2">
-    <div class="flex items-center gap-2 px-4">
-        <Sidebar.Trigger class="-ml-1"/>
-        <Separator class="mr-2 h-4" orientation="vertical"/>
-        <Breadcrumb.Root>
-            <Breadcrumb.List>
-                <Breadcrumb.Item class="hidden md:block">
-                    <Breadcrumb.Link href="{base}/dashboard">MediaManager</Breadcrumb.Link>
-                </Breadcrumb.Item>
-                <Breadcrumb.Separator class="hidden md:block"/>
-                <Breadcrumb.Item>
-                    <Breadcrumb.Link href="{base}/dashboard">Home</Breadcrumb.Link>
-                </Breadcrumb.Item>
-                <Breadcrumb.Separator class="hidden md:block"/>
-                <Breadcrumb.Item>
-                    <Breadcrumb.Link href="{base}/dashboard/tv">Shows</Breadcrumb.Link>
-                </Breadcrumb.Item>
-                <Breadcrumb.Separator class="hidden md:block"/>
-                <Breadcrumb.Item>
-                    <Breadcrumb.Page>{getFullyQualifiedMediaName(show())}</Breadcrumb.Page>
-                </Breadcrumb.Item>
-            </Breadcrumb.List>
-        </Breadcrumb.Root>
-    </div>
+	<div class="flex items-center gap-2 px-4">
+		<Sidebar.Trigger class="-ml-1" />
+		<Separator class="mr-2 h-4" orientation="vertical" />
+		<Breadcrumb.Root>
+			<Breadcrumb.List>
+				<Breadcrumb.Item class="hidden md:block">
+					<Breadcrumb.Link href="{base}/dashboard">MediaManager</Breadcrumb.Link>
+				</Breadcrumb.Item>
+				<Breadcrumb.Separator class="hidden md:block" />
+				<Breadcrumb.Item>
+					<Breadcrumb.Link href="{base}/dashboard">Home</Breadcrumb.Link>
+				</Breadcrumb.Item>
+				<Breadcrumb.Separator class="hidden md:block" />
+				<Breadcrumb.Item>
+					<Breadcrumb.Link href="{base}/dashboard/tv">Shows</Breadcrumb.Link>
+				</Breadcrumb.Item>
+				<Breadcrumb.Separator class="hidden md:block" />
+				<Breadcrumb.Item>
+					<Breadcrumb.Page>{getFullyQualifiedMediaName(show())}</Breadcrumb.Page>
+				</Breadcrumb.Item>
+			</Breadcrumb.List>
+		</Breadcrumb.Root>
+	</div>
 </header>
 <h1 class="scroll-m-20 text-center text-4xl font-extrabold tracking-tight lg:text-5xl">
-    {getFullyQualifiedMediaName(show())}
+	{getFullyQualifiedMediaName(show())}
 </h1>
 <div class="mx-auto flex w-full flex-1 flex-col gap-4 p-4 md:max-w-[80em]">
-    <div class="flex flex-col gap-4 md:flex-row md:items-stretch">
-        <div class="w-full overflow-hidden rounded-xl bg-muted/50 md:w-1/3 md:max-w-sm">
-            {#if show().id}
-                <MediaPicture media={show()}/>
-            {:else}
-                <div
-                        class="aspect-9/16 flex h-auto w-full items-center justify-center rounded-lg bg-gray-200 text-gray-500"
-                >
-                    <ImageOff size={48}/>
-                </div>
-            {/if}
-        </div>
-        <div class="w-full flex-auto rounded-xl bg-muted/50 p-4 md:w-1/4">
-            <p class="leading-7 [&:not(:first-child)]:mt-6">
-                {show().overview}
-            </p>
-        </div>
-        <div
-                class="flex w-full flex-auto flex-col items-center justify-start gap-2 rounded-xl bg-muted/50 p-4 md:w-1/3 md:max-w-[40em]"
-        >
-            {#if user().is_superuser}
-                <Card.Root class="w-full">
-                    <Card.Header>
-                        <Card.Title>Administrator Controls</Card.Title>
-                    </Card.Header>
-                    <Card.Content class="flex flex-col gap-4 items-center">
-                        {#if !show().ended}
-                            <div class="flex items-center gap-3">
-                                <Switch
-                                        bind:checked={() => continuousDownloadEnabled, toggle_continuous_download}
-                                        id="continuous-download-checkbox"
-                                />
-                                <Label for="continuous-download-checkbox">
-                                    Enable automatic download of future seasons
-                                </Label>
-                            </div>
-                        {/if}
-                        <LibraryCombobox media={show()} mediaType="tv"/>
-                    </Card.Content>
-                </Card.Root>
-            {/if}
-            <Card.Root class="w-full">
-                <Card.Header>
-                    <Card.Title>Download Options</Card.Title>
-                </Card.Header>
-                <Card.Content class="flex flex-col gap-4 items-center">
-                    {#if user().is_superuser}
-                        <DownloadSeasonDialog show={show()}/>
-                    {/if}
-                    <RequestSeasonDialog show={show()}/>
-                </Card.Content>
-            </Card.Root>
-        </div>
-    </div>
-    <div class="flex-1 rounded-xl bg-muted/50 p-4">
-        <div class="w-full overflow-x-auto">
-            <Table.Root>
-                <Table.Caption>A list of all seasons.</Table.Caption>
-                <Table.Header>
-                    <Table.Row>
-                        <Table.Head>Number</Table.Head>
-                        <Table.Head>Exists on file</Table.Head>
-                        <Table.Head>Title</Table.Head>
-                        <Table.Head>Overview</Table.Head>
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {#if show().seasons.length > 0}
-                        {#each show().seasons as season (season.id)}
-                            <Table.Row
-                                    link={true}
-                                    onclick={() => goto(base + '/dashboard/tv/' + show().id + '/' + season.id)}
-                            >
-                                <Table.Cell class="min-w-[10px] font-medium">{season.number}</Table.Cell>
-                                <Table.Cell class="min-w-[10px] font-medium">
-                                    <CheckmarkX state={season.downloaded}/>
-                                </Table.Cell>
-                                <Table.Cell class="min-w-[50px]">{season.name}</Table.Cell>
-                                <Table.Cell class="max-w-[300px] truncate">{season.overview}</Table.Cell>
-                            </Table.Row>
-                        {/each}
-                    {:else}
-                        <Table.Row>
-                            <Table.Cell colspan={3} class="text-center">No season data available.</Table.Cell>
-                        </Table.Row>
-                    {/if}
-                </Table.Body>
-            </Table.Root>
-        </div>
-    </div>
-    <div class="flex-1 rounded-xl bg-muted/50 p-4">
-        <div class="w-full overflow-x-auto">
-            <TorrentTable torrents={torrents.torrents}/>
-        </div>
-    </div>
+	<div class="flex flex-col gap-4 md:flex-row md:items-stretch">
+		<div class="w-full overflow-hidden rounded-xl bg-muted/50 md:w-1/3 md:max-w-sm">
+			{#if show().id}
+				<MediaPicture media={show()} />
+			{:else}
+				<div
+					class="aspect-9/16 flex h-auto w-full items-center justify-center rounded-lg bg-gray-200 text-gray-500"
+				>
+					<ImageOff size={48} />
+				</div>
+			{/if}
+		</div>
+		<div class="h-full w-full flex-auto rounded-xl md:w-1/4">
+			<Card.Root class="h-full w-full">
+				<Card.Header>
+					<Card.Title>Overview</Card.Title>
+				</Card.Header>
+				<Card.Content>
+					<p class="leading-7 [&:not(:first-child)]:mt-6">
+						{show().overview}
+					</p>
+				</Card.Content>
+			</Card.Root>
+		</div>
+		<div
+			class="flex h-full w-full flex-auto flex-col items-center justify-start gap-4 rounded-xl md:w-1/3 md:max-w-[40em]"
+		>
+			{#if user().is_superuser}
+				<Card.Root class="w-full  flex-1">
+					<Card.Header>
+						<Card.Title>Administrator Controls</Card.Title>
+					</Card.Header>
+					<Card.Content class="flex flex-col items-center gap-4">
+						{#if !show().ended}
+							<div class="flex items-center gap-3">
+								<Switch
+									bind:checked={() => continuousDownloadEnabled, toggle_continuous_download}
+									id="continuous-download-checkbox"
+								/>
+								<Label for="continuous-download-checkbox">
+									Enable automatic download of future seasons
+								</Label>
+							</div>
+						{/if}
+						<LibraryCombobox media={show()} mediaType="tv" />
+					</Card.Content>
+				</Card.Root>
+			{/if}
+			<Card.Root class="w-full  flex-1">
+				<Card.Header>
+					<Card.Title>Download Options</Card.Title>
+				</Card.Header>
+				<Card.Content class="flex flex-col items-center gap-4">
+					{#if user().is_superuser}
+						<DownloadSeasonDialog show={show()} />
+					{/if}
+					<RequestSeasonDialog show={show()} />
+				</Card.Content>
+			</Card.Root>
+		</div>
+	</div>
+	<div class="flex-1 rounded-xl">
+		<Card.Root class="w-full">
+			<Card.Header>
+				<Card.Title>Season Details</Card.Title>
+				<Card.Description>
+					A list of all seasons for {getFullyQualifiedMediaName(show())}.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="w-full overflow-x-auto">
+				<Table.Root>
+					<Table.Caption>A list of all seasons.</Table.Caption>
+					<Table.Header>
+						<Table.Row>
+							<Table.Head>Number</Table.Head>
+							<Table.Head>Exists on file</Table.Head>
+							<Table.Head>Title</Table.Head>
+							<Table.Head>Overview</Table.Head>
+						</Table.Row>
+					</Table.Header>
+					<Table.Body>
+						{#if show().seasons.length > 0}
+							{#each show().seasons as season (season.id)}
+								<Table.Row
+									link={true}
+									onclick={() => goto(base + '/dashboard/tv/' + show().id + '/' + season.id)}
+								>
+									<Table.Cell class="min-w-[10px] font-medium">{season.number}</Table.Cell>
+									<Table.Cell class="min-w-[10px] font-medium">
+										<CheckmarkX state={season.downloaded} />
+									</Table.Cell>
+									<Table.Cell class="min-w-[50px]">{season.name}</Table.Cell>
+									<Table.Cell class="max-w-[300px] truncate">{season.overview}</Table.Cell>
+								</Table.Row>
+							{/each}
+						{:else}
+							<Table.Row>
+								<Table.Cell colspan={3} class="text-center">No season data available.</Table.Cell>
+							</Table.Row>
+						{/if}
+					</Table.Body>
+				</Table.Root>
+			</Card.Content>
+		</Card.Root>
+	</div>
+	<div class="flex-1 rounded-xl">
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Torrent Information</Card.Title>
+				<Card.Description>A list of all torrents associated with this show.</Card.Description>
+			</Card.Header>
+
+			<Card.Content class="w-full overflow-x-auto">
+				<TorrentTable torrents={torrents.torrents} />
+			</Card.Content>
+		</Card.Root>
+	</div>
 </div>

--- a/web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte
@@ -1,176 +1,194 @@
 <script lang="ts">
-	import { env } from '$env/dynamic/public';
-	import { Separator } from '$lib/components/ui/separator/index.js';
-	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
-	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
-	import { goto } from '$app/navigation';
-	import { ImageOff } from 'lucide-svelte';
-	import * as Table from '$lib/components/ui/table/index.js';
-	import { getContext, onMount } from 'svelte';
-	import type { PublicShow, RichShowTorrent, User } from '$lib/types.js';
-	import { getFullyQualifiedMediaName } from '$lib/utils';
-	import DownloadSeasonDialog from '$lib/components/download-season-dialog.svelte';
-	import CheckmarkX from '$lib/components/checkmark-x.svelte';
-	import { page } from '$app/state';
-	import TorrentTable from '$lib/components/torrent-table.svelte';
-	import RequestSeasonDialog from '$lib/components/request-season-dialog.svelte';
-	import MediaPicture from '$lib/components/media-picture.svelte';
-	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
-	import { Switch } from '$lib/components/ui/switch/index.js';
-	import { toast } from 'svelte-sonner';
-	import { Label } from '$lib/components/ui/label';
-	import LibraryCombobox from '$lib/components/library-combobox.svelte';
-	const apiUrl = env.PUBLIC_API_URL;
-	let show: () => PublicShow = getContext('show');
-	let user: () => User = getContext('user');
-	let torrents: RichShowTorrent = page.data.torrentsData;
-	import { base } from '$app/paths';
+    import {env} from '$env/dynamic/public';
+    import {Separator} from '$lib/components/ui/separator/index.js';
+    import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+    import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
+    import {goto} from '$app/navigation';
+    import {ImageOff} from 'lucide-svelte';
+    import * as Table from '$lib/components/ui/table/index.js';
+    import {getContext, onMount} from 'svelte';
+    import type {PublicShow, RichShowTorrent, User} from '$lib/types.js';
+    import {getFullyQualifiedMediaName} from '$lib/utils';
+    import DownloadSeasonDialog from '$lib/components/download-season-dialog.svelte';
+    import CheckmarkX from '$lib/components/checkmark-x.svelte';
+    import {page} from '$app/state';
+    import TorrentTable from '$lib/components/torrent-table.svelte';
+    import RequestSeasonDialog from '$lib/components/request-season-dialog.svelte';
+    import MediaPicture from '$lib/components/media-picture.svelte';
+    import {Checkbox} from '$lib/components/ui/checkbox/index.js';
+    import {Switch} from '$lib/components/ui/switch/index.js';
+    import {toast} from 'svelte-sonner';
+    import {Label} from '$lib/components/ui/label';
+    import LibraryCombobox from '$lib/components/library-combobox.svelte';
+    import * as Card from '$lib/components/ui/card/index.js';
 
-	let continuousDownloadEnabled = $state(show().continuous_download);
+    const apiUrl = env.PUBLIC_API_URL;
+    let show: () => PublicShow = getContext('show');
+    let user: () => User = getContext('user');
+    let torrents: RichShowTorrent = page.data.torrentsData;
+    import {base} from '$app/paths';
 
-	async function toggle_continuous_download() {
-		const urlString = `${apiUrl}/tv/shows/${show().id}/continuousDownload?continuous_download=${!continuousDownloadEnabled}`;
-		console.log(
-			'Toggling continuous download for show',
-			show().name,
-			'to',
-			!continuousDownloadEnabled
-		);
-		const response = await fetch(urlString, {
-			method: 'POST',
-			credentials: 'include'
-		});
-		if (!response.ok) {
-			const errorText = await response.text();
-			toast.error('Failed to toggle continuous download: ' + errorText);
-		} else {
-			continuousDownloadEnabled = !continuousDownloadEnabled;
-			toast.success('Continuous download toggled successfully.');
-		}
-	}
+    let continuousDownloadEnabled = $state(show().continuous_download);
 
-	/*	$effect(()=>{
-		continuousDownloadEnabled;
-		toggle_continuous_download();
-	});*/
+    async function toggle_continuous_download() {
+        const urlString = `${apiUrl}/tv/shows/${show().id}/continuousDownload?continuous_download=${!continuousDownloadEnabled}`;
+        console.log(
+            'Toggling continuous download for show',
+            show().name,
+            'to',
+            !continuousDownloadEnabled
+        );
+        const response = await fetch(urlString, {
+            method: 'POST',
+            credentials: 'include'
+        });
+        if (!response.ok) {
+            const errorText = await response.text();
+            toast.error('Failed to toggle continuous download: ' + errorText);
+        } else {
+            continuousDownloadEnabled = !continuousDownloadEnabled;
+            toast.success('Continuous download toggled successfully.');
+        }
+    }
+
+    /*	$effect(()=>{
+        continuousDownloadEnabled;
+        toggle_continuous_download();
+    });*/
 </script>
 
 <svelte:head>
-	<title>{getFullyQualifiedMediaName(show())} - MediaManager</title>
-	<meta
-		content="View details and manage downloads for {getFullyQualifiedMediaName(
+    <title>{getFullyQualifiedMediaName(show())} - MediaManager</title>
+    <meta
+            content="View details and manage downloads for {getFullyQualifiedMediaName(
 			show()
 		)} in MediaManager"
-		name="description"
-	/>
+            name="description"
+    />
 </svelte:head>
 
 <header class="flex h-16 shrink-0 items-center gap-2">
-	<div class="flex items-center gap-2 px-4">
-		<Sidebar.Trigger class="-ml-1" />
-		<Separator class="mr-2 h-4" orientation="vertical" />
-		<Breadcrumb.Root>
-			<Breadcrumb.List>
-				<Breadcrumb.Item class="hidden md:block">
-					<Breadcrumb.Link href="{base}/dashboard">MediaManager</Breadcrumb.Link>
-				</Breadcrumb.Item>
-				<Breadcrumb.Separator class="hidden md:block" />
-				<Breadcrumb.Item>
-					<Breadcrumb.Link href="{base}/dashboard">Home</Breadcrumb.Link>
-				</Breadcrumb.Item>
-				<Breadcrumb.Separator class="hidden md:block" />
-				<Breadcrumb.Item>
-					<Breadcrumb.Link href="{base}/dashboard/tv">Shows</Breadcrumb.Link>
-				</Breadcrumb.Item>
-				<Breadcrumb.Separator class="hidden md:block" />
-				<Breadcrumb.Item>
-					<Breadcrumb.Page>{getFullyQualifiedMediaName(show())}</Breadcrumb.Page>
-				</Breadcrumb.Item>
-			</Breadcrumb.List>
-		</Breadcrumb.Root>
-	</div>
+    <div class="flex items-center gap-2 px-4">
+        <Sidebar.Trigger class="-ml-1"/>
+        <Separator class="mr-2 h-4" orientation="vertical"/>
+        <Breadcrumb.Root>
+            <Breadcrumb.List>
+                <Breadcrumb.Item class="hidden md:block">
+                    <Breadcrumb.Link href="{base}/dashboard">MediaManager</Breadcrumb.Link>
+                </Breadcrumb.Item>
+                <Breadcrumb.Separator class="hidden md:block"/>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Link href="{base}/dashboard">Home</Breadcrumb.Link>
+                </Breadcrumb.Item>
+                <Breadcrumb.Separator class="hidden md:block"/>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Link href="{base}/dashboard/tv">Shows</Breadcrumb.Link>
+                </Breadcrumb.Item>
+                <Breadcrumb.Separator class="hidden md:block"/>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Page>{getFullyQualifiedMediaName(show())}</Breadcrumb.Page>
+                </Breadcrumb.Item>
+            </Breadcrumb.List>
+        </Breadcrumb.Root>
+    </div>
 </header>
 <h1 class="scroll-m-20 text-center text-4xl font-extrabold tracking-tight lg:text-5xl">
-	{getFullyQualifiedMediaName(show())}
+    {getFullyQualifiedMediaName(show())}
 </h1>
 <div class="mx-auto flex w-full flex-1 flex-col gap-4 p-4 md:max-w-[80em]">
-	<div class="flex flex-col gap-4 md:flex-row md:items-stretch">
-		<div class="w-full overflow-hidden rounded-xl bg-muted/50 md:w-1/3 md:max-w-sm">
-			{#if show().id}
-				<MediaPicture media={show()} />
-			{:else}
-				<div
-					class="aspect-9/16 flex h-auto w-full items-center justify-center rounded-lg bg-gray-200 text-gray-500"
-				>
-					<ImageOff size={48} />
-				</div>
-			{/if}
-		</div>
-		<div class="w-full flex-auto rounded-xl bg-muted/50 p-4 md:w-1/4">
-			<p class="leading-7 [&:not(:first-child)]:mt-6">
-				{show().overview}
-			</p>
-		</div>
-		<div
-			class="flex w-full flex-auto flex-col items-center justify-start gap-2 rounded-xl bg-muted/50 p-4 md:w-1/3 md:max-w-[40em]"
-		>
-			{#if user().is_superuser}
-				{#if !show().ended}
-					<div class="flex items-center gap-3">
-						<Switch
-							bind:checked={() => continuousDownloadEnabled, toggle_continuous_download}
-							id="continuous-download-checkbox"
-						/>
-						<Label for="continuous-download-checkbox">
-							Enable automatic download of future seasons
-						</Label>
-					</div>
-				{/if}
-				<LibraryCombobox media={show()} mediaType="tv" />
-				<DownloadSeasonDialog show={show()} />
-			{/if}
-			<RequestSeasonDialog show={show()} />
-		</div>
-	</div>
-	<div class="flex-1 rounded-xl bg-muted/50 p-4">
-		<div class="w-full overflow-x-auto">
-			<Table.Root>
-				<Table.Caption>A list of all seasons.</Table.Caption>
-				<Table.Header>
-					<Table.Row>
-						<Table.Head>Number</Table.Head>
-						<Table.Head>Exists on file</Table.Head>
-						<Table.Head>Title</Table.Head>
-						<Table.Head>Overview</Table.Head>
-					</Table.Row>
-				</Table.Header>
-				<Table.Body>
-					{#if show().seasons.length > 0}
-						{#each show().seasons as season (season.id)}
-							<Table.Row
-								link={true}
-								onclick={() => goto(base + '/dashboard/tv/' + show().id + '/' + season.id)}
-							>
-								<Table.Cell class="min-w-[10px] font-medium">{season.number}</Table.Cell>
-								<Table.Cell class="min-w-[10px] font-medium">
-									<CheckmarkX state={season.downloaded} />
-								</Table.Cell>
-								<Table.Cell class="min-w-[50px]">{season.name}</Table.Cell>
-								<Table.Cell class="max-w-[300px] truncate">{season.overview}</Table.Cell>
-							</Table.Row>
-						{/each}
-					{:else}
-						<Table.Row>
-							<Table.Cell colspan={3} class="text-center">No season data available.</Table.Cell>
-						</Table.Row>
-					{/if}
-				</Table.Body>
-			</Table.Root>
-		</div>
-	</div>
-	<div class="flex-1 rounded-xl bg-muted/50 p-4">
-		<div class="w-full overflow-x-auto">
-			<TorrentTable torrents={torrents.torrents} />
-		</div>
-	</div>
+    <div class="flex flex-col gap-4 md:flex-row md:items-stretch">
+        <div class="w-full overflow-hidden rounded-xl bg-muted/50 md:w-1/3 md:max-w-sm">
+            {#if show().id}
+                <MediaPicture media={show()}/>
+            {:else}
+                <div
+                        class="aspect-9/16 flex h-auto w-full items-center justify-center rounded-lg bg-gray-200 text-gray-500"
+                >
+                    <ImageOff size={48}/>
+                </div>
+            {/if}
+        </div>
+        <div class="w-full flex-auto rounded-xl bg-muted/50 p-4 md:w-1/4">
+            <p class="leading-7 [&:not(:first-child)]:mt-6">
+                {show().overview}
+            </p>
+        </div>
+        <div
+                class="flex w-full flex-auto flex-col items-center justify-start gap-2 rounded-xl bg-muted/50 p-4 md:w-1/3 md:max-w-[40em]"
+        >
+            {#if user().is_superuser}
+                <Card.Root class="w-full">
+                    <Card.Header>
+                        <Card.Title>Administrator Controls</Card.Title>
+                    </Card.Header>
+                    <Card.Content class="flex flex-col gap-4 items-center">
+                        {#if !show().ended}
+                            <div class="flex items-center gap-3">
+                                <Switch
+                                        bind:checked={() => continuousDownloadEnabled, toggle_continuous_download}
+                                        id="continuous-download-checkbox"
+                                />
+                                <Label for="continuous-download-checkbox">
+                                    Enable automatic download of future seasons
+                                </Label>
+                            </div>
+                        {/if}
+                        <LibraryCombobox media={show()} mediaType="tv"/>
+                    </Card.Content>
+                </Card.Root>
+            {/if}
+            <Card.Root class="w-full">
+                <Card.Header>
+                    <Card.Title>Download Options</Card.Title>
+                </Card.Header>
+                <Card.Content class="flex flex-col gap-4 items-center">
+                    {#if user().is_superuser}
+                        <DownloadSeasonDialog show={show()}/>
+                    {/if}
+                    <RequestSeasonDialog show={show()}/>
+                </Card.Content>
+            </Card.Root>
+        </div>
+    </div>
+    <div class="flex-1 rounded-xl bg-muted/50 p-4">
+        <div class="w-full overflow-x-auto">
+            <Table.Root>
+                <Table.Caption>A list of all seasons.</Table.Caption>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.Head>Number</Table.Head>
+                        <Table.Head>Exists on file</Table.Head>
+                        <Table.Head>Title</Table.Head>
+                        <Table.Head>Overview</Table.Head>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {#if show().seasons.length > 0}
+                        {#each show().seasons as season (season.id)}
+                            <Table.Row
+                                    link={true}
+                                    onclick={() => goto(base + '/dashboard/tv/' + show().id + '/' + season.id)}
+                            >
+                                <Table.Cell class="min-w-[10px] font-medium">{season.number}</Table.Cell>
+                                <Table.Cell class="min-w-[10px] font-medium">
+                                    <CheckmarkX state={season.downloaded}/>
+                                </Table.Cell>
+                                <Table.Cell class="min-w-[50px]">{season.name}</Table.Cell>
+                                <Table.Cell class="max-w-[300px] truncate">{season.overview}</Table.Cell>
+                            </Table.Row>
+                        {/each}
+                    {:else}
+                        <Table.Row>
+                            <Table.Cell colspan={3} class="text-center">No season data available.</Table.Cell>
+                        </Table.Row>
+                    {/if}
+                </Table.Body>
+            </Table.Root>
+        </div>
+    </div>
+    <div class="flex-1 rounded-xl bg-muted/50 p-4">
+        <div class="w-full overflow-x-auto">
+            <TorrentTable torrents={torrents.torrents}/>
+        </div>
+    </div>
 </div>

--- a/web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte
@@ -6,7 +6,7 @@
 	import { goto } from '$app/navigation';
 	import { ImageOff } from 'lucide-svelte';
 	import * as Table from '$lib/components/ui/table/index.js';
-	import { getContext } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 	import type { PublicShow, RichShowTorrent, User } from '$lib/types.js';
 	import { getFullyQualifiedMediaName } from '$lib/utils';
 	import DownloadSeasonDialog from '$lib/components/download-season-dialog.svelte';
@@ -16,6 +16,7 @@
 	import RequestSeasonDialog from '$lib/components/request-season-dialog.svelte';
 	import MediaPicture from '$lib/components/media-picture.svelte';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { Switch } from '$lib/components/ui/switch/index.js';
 	import { toast } from 'svelte-sonner';
 	import { Label } from '$lib/components/ui/label';
 	import LibraryCombobox from '$lib/components/library-combobox.svelte';
@@ -25,13 +26,15 @@
 	let torrents: RichShowTorrent = page.data.torrentsData;
 	import { base } from '$app/paths';
 
+	let continuousDownloadEnabled = $state(show().continuous_download);
+
 	async function toggle_continuous_download() {
-		const urlString = `${apiUrl}/tv/shows/${show().id}/continuousDownload?continuous_download=${!show().continuous_download}`;
+		const urlString = `${apiUrl}/tv/shows/${show().id}/continuousDownload?continuous_download=${!continuousDownloadEnabled}`;
 		console.log(
 			'Toggling continuous download for show',
 			show().name,
 			'to',
-			!show().continuous_download
+			!continuousDownloadEnabled
 		);
 		const response = await fetch(urlString, {
 			method: 'POST',
@@ -41,10 +44,15 @@
 			const errorText = await response.text();
 			toast.error('Failed to toggle continuous download: ' + errorText);
 		} else {
-			show().continuous_download = !show().continuous_download;
+			continuousDownloadEnabled = !continuousDownloadEnabled;
 			toast.success('Continuous download toggled successfully.');
 		}
 	}
+
+	/*	$effect(()=>{
+		continuousDownloadEnabled;
+		toggle_continuous_download();
+	});*/
 </script>
 
 <svelte:head>
@@ -85,7 +93,7 @@
 <h1 class="scroll-m-20 text-center text-4xl font-extrabold tracking-tight lg:text-5xl">
 	{getFullyQualifiedMediaName(show())}
 </h1>
-<div class="flex w-full flex-1 flex-col gap-4 p-4">
+<div class="mx-auto flex w-full flex-1 flex-col gap-4 p-4 md:max-w-[80em]">
 	<div class="flex flex-col gap-4 md:flex-row md:items-stretch">
 		<div class="w-full overflow-hidden rounded-xl bg-muted/50 md:w-1/3 md:max-w-sm">
 			{#if show().id}
@@ -103,30 +111,23 @@
 				{show().overview}
 			</p>
 		</div>
-		<div class="w-full flex-auto rounded-xl bg-muted/50 p-4 md:w-1/3">
+		<div
+			class="flex w-full flex-auto flex-col items-center justify-start gap-2 rounded-xl bg-muted/50 p-4 md:w-1/3 md:max-w-[40em]"
+		>
 			{#if user().is_superuser}
 				{#if !show().ended}
-					<div class="mx-1 my-2 block">
-						<Checkbox
-							checked={show().continuous_download}
-							onCheckedChange={() => {
-								toggle_continuous_download();
-							}}
+					<div class="flex items-center gap-3">
+						<Switch
+							bind:checked={() => continuousDownloadEnabled, toggle_continuous_download}
 							id="continuous-download-checkbox"
 						/>
 						<Label for="continuous-download-checkbox">
 							Enable automatic download of future seasons
 						</Label>
-						<hr />
 					</div>
 				{/if}
-				<div class="mx-1 my-2 block">
-					<LibraryCombobox media={show()} mediaType="tv" />
-					<Label for="library-combobox">Select Library for this show</Label>
-					<hr />
-				</div>
+				<LibraryCombobox media={show()} mediaType="tv" />
 				<DownloadSeasonDialog show={show()} />
-				<div class="my-2"></div>
 			{/if}
 			<RequestSeasonDialog show={show()} />
 		</div>

--- a/web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelte
@@ -10,6 +10,7 @@
 	import { getFullyQualifiedMediaName, getTorrentQualityString } from '$lib/utils';
 	import MediaPicture from '$lib/components/media-picture.svelte';
 	import { base } from '$app/paths';
+	import * as Card from '$lib/components/ui/card/index.js';
 
 	let seasonFiles: PublicSeasonFile[] = $state(page.data.files);
 	let season: Season = $state(page.data.season);
@@ -63,65 +64,95 @@
 <h1 class="scroll-m-20 text-center text-4xl font-extrabold tracking-tight lg:text-5xl">
 	{getFullyQualifiedMediaName(show())} Season {season.number}
 </h1>
-<div class="flex flex-1 flex-col gap-4 p-4">
+<div class="mx-auto flex w-full flex-1 flex-col gap-4 p-4 md:max-w-[80em]">
 	<div class="flex flex-col gap-4 md:flex-row md:items-stretch">
 		<div class="w-full overflow-hidden rounded-xl bg-muted/50 md:w-1/3 md:max-w-sm">
 			<MediaPicture media={show()} />
 		</div>
-		<div class="w-full flex-auto rounded-xl bg-muted/50 p-4 md:w-1/4">
-			<p class="leading-7 [&:not(:first-child)]:mt-6">
-				{show().overview}
-			</p>
+		<div class="h-full w-full flex-auto rounded-xl md:w-1/4">
+			<Card.Root class="h-full w-full">
+				<Card.Header>
+					<Card.Title>Overview</Card.Title>
+				</Card.Header>
+				<Card.Content>
+					<p class="leading-7 [&:not(:first-child)]:mt-6">
+						{show().overview}
+					</p>
+				</Card.Content>
+			</Card.Root>
 		</div>
-		<div class="w-full flex-auto rounded-xl bg-muted/50 p-4 md:w-1/3">
-			<Table.Root>
-				<Table.Caption>A list of all downloaded/downloading versions of this season.</Table.Caption>
-				<Table.Header>
-					<Table.Row>
-						<Table.Head>Quality</Table.Head>
-						<Table.Head>File Path Suffix</Table.Head>
-						<Table.Head>Imported</Table.Head>
-					</Table.Row>
-				</Table.Header>
-				<Table.Body>
-					{#each seasonFiles as file}
-						<Table.Row>
-							<Table.Cell class="w-[50px]">
-								{getTorrentQualityString(file.quality)}
-							</Table.Cell>
-							<Table.Cell class="w-[100px]">
-								{file.file_path_suffix}
-							</Table.Cell>
-							<Table.Cell class="w-[10px] font-medium">
-								<CheckmarkX state={file.downloaded} />
-							</Table.Cell>
-						</Table.Row>
-					{:else}
-						<span class="font-semibold">You haven't downloaded this season yet.</span>
-					{/each}
-				</Table.Body>
-			</Table.Root>
+		<div
+			class="flex h-full w-full flex-auto flex-col items-center justify-start gap-4 rounded-xl md:w-1/3 md:max-w-[40em]"
+		>
+			<Card.Root class="h-full w-full">
+				<Card.Header>
+					<Card.Title>Season Details</Card.Title>
+					<Card.Description>
+						A list of all downloaded/downloading versions of this season.
+					</Card.Description>
+				</Card.Header>
+				<Card.Content>
+					<Table.Root>
+						<Table.Caption
+							>A list of all downloaded/downloading versions of this season.</Table.Caption
+						>
+						<Table.Header>
+							<Table.Row>
+								<Table.Head>Quality</Table.Head>
+								<Table.Head>File Path Suffix</Table.Head>
+								<Table.Head>Imported</Table.Head>
+							</Table.Row>
+						</Table.Header>
+						<Table.Body>
+							{#each seasonFiles as file}
+								<Table.Row>
+									<Table.Cell class="w-[50px]">
+										{getTorrentQualityString(file.quality)}
+									</Table.Cell>
+									<Table.Cell class="w-[100px]">
+										{file.file_path_suffix}
+									</Table.Cell>
+									<Table.Cell class="w-[10px] font-medium">
+										<CheckmarkX state={file.downloaded} />
+									</Table.Cell>
+								</Table.Row>
+							{:else}
+								<span class="font-semibold">You haven't downloaded this season yet.</span>
+							{/each}
+						</Table.Body>
+					</Table.Root>
+				</Card.Content>
+			</Card.Root>
 		</div>
 	</div>
-	<div class="flex-1 rounded-xl bg-muted/50 p-4">
-		<div class="w-full overflow-x-auto">
-			<Table.Root>
-				<Table.Caption>A list of all episodes.</Table.Caption>
-				<Table.Header>
-					<Table.Row>
-						<Table.Head class="w-[100px]">Number</Table.Head>
-						<Table.Head class="min-w-[50px]">Title</Table.Head>
-					</Table.Row>
-				</Table.Header>
-				<Table.Body>
-					{#each season.episodes as episode (episode.id)}
+	<div class="flex-1 rounded-xl">
+		<Card.Root class="w-full">
+			<Card.Header>
+				<Card.Title>Episodes</Card.Title>
+				<Card.Description
+					>A list of all episodes for {getFullyQualifiedMediaName(show())} Season {season.number}
+					.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="w-full overflow-x-auto">
+				<Table.Root>
+					<Table.Caption>A list of all episodes.</Table.Caption>
+					<Table.Header>
 						<Table.Row>
-							<Table.Cell class="w-[100px] font-medium">{episode.number}</Table.Cell>
-							<Table.Cell class="min-w-[50px]">{episode.title}</Table.Cell>
+							<Table.Head class="w-[100px]">Number</Table.Head>
+							<Table.Head class="min-w-[50px]">Title</Table.Head>
 						</Table.Row>
-					{/each}
-				</Table.Body>
-			</Table.Root>
-		</div>
+					</Table.Header>
+					<Table.Body>
+						{#each season.episodes as episode (episode.id)}
+							<Table.Row>
+								<Table.Cell class="w-[100px] font-medium">{episode.number}</Table.Cell>
+								<Table.Cell class="min-w-[50px]">{episode.title}</Table.Cell>
+							</Table.Row>
+						{/each}
+					</Table.Body>
+				</Table.Root>
+			</Card.Content>
+		</Card.Root>
 	</div>
 </div>


### PR DESCRIPTION
This pull request introduces several changes across the backend and frontend to improve the handling of movie and TV show data, enhance UI components, and refactor certain functionalities. The changes include schema updates, API adjustments, and significant UI enhancements using reusable components like `Card` and `Switch`. Below is a summary of the most important changes grouped by theme:

### Backend Enhancements
1. **Schema Updates:**
   - Added a `torrents` field to the `PublicMovie` schema and moved its definition to include this new field (`media_manager/movies/schemas.py`, [[1]](diffhunk://#diff-873fd1416b62c7db5cb971f08ea4fbab495ea1fbee01ad492000f98d402fd5e9L41-L44) [[2]](diffhunk://#diff-873fd1416b62c7db5cb971f08ea4fbab495ea1fbee01ad492000f98d402fd5e9R86-R90).
   - Introduced a `library` field in the `PublicShow` schema to store associated library information (`media_manager/tv/schemas.py`, [media_manager/tv/schemas.pyR166](diffhunk://#diff-321e2b5a9ecfc41d1421ccb3781343a16d140fe6bddd0f9abbcc1e1ad79865deR166)).

2. **Service Logic:**
   - Updated the `get_public_movie_by_id` method to include torrent information when fetching a public movie (`media_manager/movies/service.py`, [media_manager/movies/service.pyR262-R265](diffhunk://#diff-57cfa309860beba31573487107eba3f7ef8ef60429c48c02fb262b9f4ff9b8d3R262-R265)).

### Frontend Enhancements
1. **UI Improvements:**
   - Replaced hardcoded UI components with reusable `Card` components for better structure and maintainability in movie, show, and season dashboards (`web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte`, [web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelteL61-R60](diffhunk://#diff-5b090fcfc48dd566a679dfa14a87f05abb1c86d732748e489bfdf2d003866f50L61-R60), [web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelteL74-R120](diffhunk://#diff-5b090fcfc48dd566a679dfa14a87f05abb1c86d732748e489bfdf2d003866f50L74-R120), [web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelteL74-R120](diffhunk://#diff-5b090fcfc48dd566a679dfa14a87f05abb1c86d732748e489bfdf2d003866f50L74-R120); `web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte`, [web/src/routes/dashboard/tv/[showId=uuid]/+page.svelteL101-R167](diffhunk://#diff-a31125f046ac164d639c6311ac618cf6ba0b9652231f119958e5b4f9dfa67f70L101-R167), [web/src/routes/dashboard/tv/[showId=uuid]/+page.svelteR200-R213](diffhunk://#diff-a31125f046ac164d639c6311ac618cf6ba0b9652231f119958e5b4f9dfa67f70R200-R213); `web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelte`, [web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelteL66-R98](diffhunk://#diff-96454e53f558bda9bb22c7c4097ae27751229e9c09c0f7902accd15837add96fL66-R98), [web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelteR124-R137](diffhunk://#diff-96454e53f558bda9bb22c7c4097ae27751229e9c09c0f7902accd15837add96fR124-R137)).
   - Introduced a `Switch` component for toggling features like continuous downloads, replacing the previous `Checkbox` implementation (`web/src/lib/components/ui/switch/index.ts`, [[1]](diffhunk://#diff-67dc7a678e215751930af30d5417c752bc449e2f7a701c7bec45d4c7791ca866R1-R7); `web/src/lib/components/ui/switch/switch.svelte`, [[2]](diffhunk://#diff-c71fb238bd6e686ec7505f3e011457bf7fcbdfc0aae4723b1b1e1060410d877dR1-R27); `web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte`, [web/src/routes/dashboard/tv/[showId=uuid]/+page.svelteL18-R38](diffhunk://#diff-a31125f046ac164d639c6311ac618cf6ba0b9652231f119958e5b4f9dfa67f70L18-R38), [web/src/routes/dashboard/tv/[showId=uuid]/+page.svelteL101-R167](diffhunk://#diff-a31125f046ac164d639c6311ac618cf6ba0b9652231f119958e5b4f9dfa67f70L101-R167)).

2. **Frontend Data Handling:**
   - Updated the `PublicMovie` type to include a `torrents` field, aligning with backend changes (`web/src/lib/types.ts`, [web/src/lib/types.tsR152](diffhunk://#diff-8bfc6d05515c14ef4f624f33c1472580241d0cb279a5cd6782174d2730e03984R152)).
   - Removed unnecessary `torrents` data from the movie dashboard page load function, simplifying data fetching (`web/src/routes/dashboard/movies/[movieId=uuid]/+page.ts`, [web/src/routes/dashboard/movies/[movieId=uuid]/+page.tsL11-R12](diffhunk://#diff-15b99a0f9e94c4cf298ab33ca1c1fe5e50616f93b70f0e1dafec1c5a2339dbb5L11-R12)).

3. **UI Refinements:**
   - Standardized layout widths and responsiveness across movie, show, and season dashboards for a more consistent user experience (`web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte`, [web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelteL61-R60](diffhunk://#diff-5b090fcfc48dd566a679dfa14a87f05abb1c86d732748e489bfdf2d003866f50L61-R60); `web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte`, [web/src/routes/dashboard/tv/[showId=uuid]/+page.svelteL88-R97](diffhunk://#diff-a31125f046ac164d639c6311ac618cf6ba0b9652231f119958e5b4f9dfa67f70L88-R97); `web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelte`, [web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelteL66-R98](diffhunk://#diff-96454e53f558bda9bb22c7c4097ae27751229e9c09c0f7902accd15837add96fL66-R98)).

### Bug Fixes and Minor Adjustments
1. **UI Bug Fixes:**
   - Fixed the display logic for torrent titles in the torrent table (`web/src/lib/components/torrent-table.svelte`, [web/src/lib/components/torrent-table.svelteL31-R31](diffhunk://#diff-d690773858f41bda8e8807d25d825cd067950352eb2bad095e629b0d5177df1dL31-R31)).
   - Simplified the `LibraryCombobox` default label logic (`web/src/lib/components/library-combobox.svelte`, [web/src/lib/components/library-combobox.svelteL100-R100](diffhunk://#diff-7ef5904972a911e552392d4977eb1be0785c729a7edcdda43372331646646a21L100-R100)).

These changes collectively improve the maintainability, functionality, and user experience of the application.

This PR fixes #125, #126.