### PR TITLE
Change all URLs containing maxid.me to dorninger.co

### DIFF
--- a/Writerside/topics/metadata-provider-configuration.md
+++ b/Writerside/topics/metadata-provider-configuration.md
@@ -14,7 +14,7 @@ TMDB (The Movie Database) is the primary metadata provider for MediaManager. It 
 
 If you want to use your own TMDB relay service, set this to the URL of your own MetadataRelay. Otherwise, use the default relay.
 
-- **Default:** `https://metadata-relay.maxid.me/tmdb`
+- **Default:** `https://metadata-relay.dorninger.co/tmdb`
 - **Example:** `https://your-own-relay.example.com/tmdb`
 
 ## TVDB Settings (`[metadata.tvdb]`)
@@ -27,7 +27,7 @@ If you want to use your own TMDB relay service, set this to the URL of your own 
 
 If you want to use your own TVDB relay service, set this to the URL of your own MetadataRelay. Otherwise, use the default relay.
 
-- **Default:** `https://metadata-relay.maxid.me/tvdb`
+- **Default:** `https://metadata-relay.dorninger.co/tvdb`
 - **Example:** `https://your-own-relay.example.com/tvdb`
 
 ## MetadataRelay
@@ -57,11 +57,11 @@ Here's a complete example of the metadata section in your `config.toml`:
 [metadata]
     # TMDB configuration
     [metadata.tmdb]
-    tmdb_relay_url = "https://metadata-relay.maxid.me/tmdb"
+    tmdb_relay_url = "https://metadata-relay.dorninger.co/tmdb"
 
     # TVDB configuration  
     [metadata.tvdb]
-    tvdb_relay_url = "https://metadata-relay.maxid.me/tvdb"
+    tvdb_relay_url = "https://metadata-relay.dorninger.co/tvdb"
 ```
 
 <note>

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -167,7 +167,7 @@ rule_names = ["prefer_h265", "avoid_cam", "reject_non_freeleech"]
 # its very unlikely that you need to change this
 [metadata]
 [metadata.tmdb]
-tmdb_relay_url = "https://metadata-relay.maxid.me/tmdb"
+tmdb_relay_url = "https://metadata-relay.dorninger.co/tmdb"
 
 [metadata.tvdb]
-tvdb_relay_url = "https://metadata-relay.maxid.me/tvdb"
+tvdb_relay_url = "https://metadata-relay.dorninger.co/tvdb"

--- a/config.example.toml
+++ b/config.example.toml
@@ -167,7 +167,7 @@ rule_names = ["prefer_h265", "avoid_cam", "reject_non_freeleech"]
 # its very unlikely that you need to change this
 [metadata]
 [metadata.tmdb]
-tmdb_relay_url = "https://metadata-relay.maxid.me/tmdb"
+tmdb_relay_url = "https://metadata-relay.dorninger.co/tmdb"
 
 [metadata.tvdb]
-tvdb_relay_url = "https://metadata-relay.maxid.me/tvdb"
+tvdb_relay_url = "https://metadata-relay.dorninger.co/tvdb"

--- a/media_manager/metadataProvider/config.py
+++ b/media_manager/metadataProvider/config.py
@@ -2,11 +2,11 @@ from pydantic_settings import BaseSettings
 
 
 class TmdbConfig(BaseSettings):
-    tmdb_relay_url: str = "https://metadata-relay.maxid.me/tmdb"
+    tmdb_relay_url: str = "https://metadata-relay.dorninger.co/tmdb"
 
 
 class TvdbConfig(BaseSettings):
-    tvdb_relay_url: str = "https://metadata-relay.maxid.me/tvdb"
+    tvdb_relay_url: str = "https://metadata-relay.dorninger.co/tvdb"
 
 
 class MetadataProviderConfig(BaseSettings):

--- a/metadata_relay/README.md
+++ b/metadata_relay/README.md
@@ -2,7 +2,7 @@
 
 This is a service that provides metadata for movies and TV shows. It caches the metadata to not overload the TMDB and
 TVDB APIs. This service is used by MediaManager to fetch metadata for movies and TV shows. I (the developer) run a
-public instance of this service at https://metadata-relay.maxid.me, but you can also run your
+public instance of this service at https://metadata-relay.dorninger.co, but you can also run your
 own instance.
 
 ## Example Docker Compose Configuration


### PR DESCRIPTION
This pull request updates the default URLs for the TMDB and TVDB metadata relay services throughout the codebase and documentation. The new default relay is now `https://metadata-relay.dorninger.co`, replacing the previous `maxid.me` domain.