### PR TITLE
Fix credentials being leaked in logs

### DIFF
--- a/media_manager/auth/users.py
+++ b/media_manager/auth/users.py
@@ -138,7 +138,7 @@ async def create_default_admin_user():
                         admin_email = (
                             config.auth.admin_emails[0]
                             if config.auth.admin_emails
-                            else "admin@mediamanager.local"
+                            else "admin@example.com"
                         )
                         default_password = "admin"  # Simple default password
 

--- a/media_manager/auth/users.py
+++ b/media_manager/auth/users.py
@@ -50,7 +50,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         update_dict: dict[str, Any],
         request: Optional[Request] = None,
     ) -> None:
-        log.info(f"User {user.id} has been updated. Changes: {update_dict}")
+        log.info(f"User {user.id} has been updated.")
         if "is_superuser" in update_dict and update_dict["is_superuser"]:
             log.info(f"User {user.id} has been granted superuser privileges.")
         if "email" in update_dict:


### PR DESCRIPTION
This PR changes the default email to admin@example.com and prevents leaking of credentials via the logs. It fixes #144.