### PR TITLE
Add NZBGet support as usenet download client

### DIFF
--- a/Writerside/topics/download-client-configuration.md
+++ b/Writerside/topics/download-client-configuration.md
@@ -1,6 +1,6 @@
 # Download Clients
 
-Download client settings are configured in the `[torrents]` section of your `config.toml` file. MediaManager supports both qBittorrent and SABnzbd as download clients.
+Download client settings are configured in the `[torrents]` section of your `config.toml` file. MediaManager supports qBittorrent and Transmission as torrent clients, and SABnzbd and NZBGet as usenet clients.
 
 ## qBittorrent Settings (`[torrents.qbittorrent]`)
 
@@ -88,6 +88,34 @@ API key for SABnzbd. You can find this in SABnzbd's configuration under "General
 
 API base path for SABnzbd. It usually ends with `/api`, the default is `/api`.
 
+## NZBGet Settings (`[torrents.nzbget]`)
+
+NZBGet is a high-performance Usenet downloader that MediaManager can integrate with for downloading NZB files.
+
+- `enabled`
+
+Set to `true` to enable NZBGet integration. Default is `false`.
+
+- `host`
+
+Hostname or IP of the NZBGet server (without protocol).
+
+- `port`
+
+Port of the NZBGet web interface. Default is `6789`.
+
+- `username`
+
+Username for NZBGet authentication. Default is `nzbget`.
+
+- `password`
+
+Password for NZBGet authentication. Default is `tegbzn6789`.
+
+- `use_https`
+
+Set to `true` if your NZBGet uses HTTPS. Default is `false`.
+
 ## Example Configuration
 
 Here's a complete example of the download clients section in your `config.toml`:
@@ -118,6 +146,15 @@ Here's a complete example of the download clients section in your `config.toml`:
     host = "http://sabnzbd"
     port = 8080
     api_key = "your_sabnzbd_api_key"
+
+    # NZBGet configuration
+    [torrents.nzbget]
+    enabled = false
+    host = "nzbget"
+    port = 6789
+    username = "nzbget"
+    password = "your_nzbget_password"
+    use_https = false
 ```
 
 ## Docker Compose Integration
@@ -147,6 +184,15 @@ services:
     image: lscr.io/linuxserver/sabnzbd:latest
     ports:
       - "8081:8080"
+    volumes:
+      - ./data/usenet:/downloads
+    # ... other configuration ...
+
+  # NZBGet service
+  nzbget:
+    image: lscr.io/linuxserver/nzbget:latest
+    ports:
+      - "6789:6789"
     volumes:
       - ./data/usenet:/downloads
     # ... other configuration ...

--- a/config.example.toml
+++ b/config.example.toml
@@ -113,6 +113,15 @@ port = 8080
 api_key = ""
 base_path = "/api"
 
+# NZBGet settings
+[torrents.nzbget]
+enabled = false
+host = "localhost"
+port = 6789
+username = "nzbget"
+password = "tegbzn6789"
+use_https = false
+
 [indexers]
 # Prowlarr settings
 [indexers.prowlarr]

--- a/media_manager/torrent/config.py
+++ b/media_manager/torrent/config.py
@@ -33,7 +33,18 @@ class SabnzbdConfig(BaseSettings):
     base_path: str = "/api"
 
 
+class NzbgetConfig(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="NZBGET_")
+    host: str = "localhost"
+    port: int = 6789
+    username: str = "nzbget"
+    password: str = "tegbzn6789"
+    use_https: bool = False
+    enabled: bool = False
+
+
 class TorrentConfig(BaseSettings):
     qbittorrent: QbittorrentConfig = QbittorrentConfig()
     transmission: TransmissionConfig = TransmissionConfig()
     sabnzbd: SabnzbdConfig = SabnzbdConfig()
+    nzbget: NzbgetConfig = NzbgetConfig()

--- a/media_manager/torrent/download_clients/nzbget.py
+++ b/media_manager/torrent/download_clients/nzbget.py
@@ -1,0 +1,228 @@
+import logging
+
+from media_manager.config import AllEncompassingConfig
+from media_manager.indexer.schemas import IndexerQueryResult
+from media_manager.torrent.download_clients.abstractDownloadClient import (
+    AbstractDownloadClient,
+)
+from media_manager.torrent.schemas import Torrent, TorrentStatus
+import pynzbgetapi
+
+log = logging.getLogger(__name__)
+
+
+class NzbgetDownloadClient(AbstractDownloadClient):
+    name = "nzbget"
+
+    # NZBGet status mappings
+    # See: https://nzbget.com/documentation/api/listgroups/
+    DOWNLOADING_STATE = (
+        "QUEUED",
+        "PAUSED",
+        "DOWNLOADING",
+        "FETCHING",
+        "PP_QUEUED",
+        "LOADING_PARS",
+        "VERIFYING_SOURCES",
+        "REPAIRING",
+        "VERIFYING_REPAIRED",
+        "RENAMING",
+        "UNPACKING",
+        "MOVING",
+        "EXECUTING_SCRIPT",
+    )
+    FINISHED_STATE = ("PP_FINISHED",)
+    ERROR_STATE = ("PP_ERROR",)
+
+    def __init__(self):
+        self.config = AllEncompassingConfig().torrents.nzbget
+        protocol = "https" if self.config.use_https else "http"
+        host_url = f"{protocol}://{self.config.host}:{self.config.port}"
+
+        self.client = pynzbgetapi.NZBGetAPI(
+            host_url,
+            self.config.username,
+            self.config.password,
+        )
+
+        try:
+            # Test connection
+            version = self.client.version()
+            log.info(f"Successfully connected to NZBGet version: {version}")
+        except Exception as e:
+            log.error(f"Failed to connect to NZBGet: {e}")
+            raise
+
+    def download_torrent(self, indexer_result: IndexerQueryResult) -> Torrent:
+        """
+        Add a NZB to NZBGet and return the torrent object.
+
+        :param indexer_result: The indexer query result of the NZB file to download.
+        :return: The torrent object with calculated hash and initial status.
+        """
+        log.info(f"Attempting to download NZB: {indexer_result.title}")
+
+        try:
+            # Add NZB to NZBGet queue using URL
+            # append(NZBFilename, Content, Category, Priority, AddToTop, AddPaused, DupeKey, DupeScore, DupeMode, PPParameters)
+            # When Content is a URL, NZBFilename can be empty
+            nzb_id = self.client.append(
+                "",  # NZBFilename - empty when using URL
+                str(indexer_result.download_url),  # Content - URL to fetch NZB from
+                "",  # Category
+                0,  # Priority (0 = normal)
+                False,  # AddToTop
+                False,  # AddPaused
+                "",  # DupeKey
+                0,  # DupeScore
+                "SCORE",  # DupeMode
+                [],  # PPParameters
+            )
+
+            if not nzb_id or nzb_id <= 0:
+                error_msg = f"NZBGet returned invalid ID: {nzb_id}"
+                log.error(f"Failed to add NZB to NZBGet: {error_msg}")
+                raise RuntimeError(f"Failed to add NZB to NZBGet: {error_msg}")
+
+            log.info(
+                f"Successfully added NZB: {indexer_result.title} with ID: {nzb_id}"
+            )
+
+            # Create and return torrent object
+            # Use the NZBGet ID as the hash
+            torrent = Torrent(
+                status=TorrentStatus.unknown,
+                title=indexer_result.title,
+                quality=indexer_result.quality,
+                imported=False,
+                hash=str(nzb_id),
+                usenet=True,
+            )
+
+            # Get initial status from NZBGet
+            torrent.status = self.get_torrent_status(torrent)
+
+            return torrent
+
+        except Exception as e:
+            log.error(f"Failed to download NZB {indexer_result.title}: {e}")
+            raise
+
+    def remove_torrent(self, torrent: Torrent, delete_data: bool = False) -> None:
+        """
+        Remove a download from NZBGet.
+
+        :param torrent: The torrent to remove.
+        :param delete_data: Whether to delete the downloaded files.
+        """
+        log.info(f"Removing download: {torrent.title} (Delete data: {delete_data})")
+        try:
+            nzb_id = int(torrent.hash)
+            # editqueue(Command, Offset, EditText, IDs)
+            # GroupDelete command removes the group from queue
+            self.client.editqueue("GroupDelete", 0, "", [nzb_id])
+            log.info(f"Successfully removed download: {torrent.title}")
+        except Exception as e:
+            log.error(f"Failed to remove download {torrent.title}: {e}")
+            raise
+
+    def pause_torrent(self, torrent: Torrent) -> None:
+        """
+        Pause a download in NZBGet.
+
+        :param torrent: The torrent to pause.
+        """
+        log.info(f"Pausing download: {torrent.title}")
+        try:
+            nzb_id = int(torrent.hash)
+            # GroupPause command pauses the group
+            self.client.editqueue("GroupPause", 0, "", [nzb_id])
+            log.info(f"Successfully paused download: {torrent.title}")
+        except Exception as e:
+            log.error(f"Failed to pause download {torrent.title}: {e}")
+            raise
+
+    def resume_torrent(self, torrent: Torrent) -> None:
+        """
+        Resume a paused download in NZBGet.
+
+        :param torrent: The torrent to resume.
+        """
+        log.info(f"Resuming download: {torrent.title}")
+        try:
+            nzb_id = int(torrent.hash)
+            # GroupResume command resumes the group
+            self.client.editqueue("GroupResume", 0, "", [nzb_id])
+            log.info(f"Successfully resumed download: {torrent.title}")
+        except Exception as e:
+            log.error(f"Failed to resume download {torrent.title}: {e}")
+            raise
+
+    def get_torrent_status(self, torrent: Torrent) -> TorrentStatus:
+        """
+        Get the status of a specific download from NZBGet.
+
+        :param torrent: The torrent to get the status of.
+        :return: The status of the torrent.
+        """
+        log.info(f"Fetching status for download: {torrent.title}")
+        try:
+            nzb_id = int(torrent.hash)
+            groups = self.client.listgroups()
+
+            for group in groups:
+                if group.get("NZBID") == nzb_id:
+                    status = group.get("Status", "UNKNOWN")
+                    log.info(f"Download status for NZB {torrent.title}: {status}")
+                    return self._map_status(status)
+
+            # If not found in active queue, check history
+            history = self.client.history()
+            for item in history:
+                if item.get("NZBID") == nzb_id:
+                    status = item.get("Status", "UNKNOWN")
+                    log.info(
+                        f"Download status for NZB {torrent.title} (from history): {status}"
+                    )
+                    return self._map_history_status(status)
+
+            log.warning(f"Download not found in NZBGet: {torrent.title}")
+            return TorrentStatus.unknown
+
+        except Exception as e:
+            log.error(f"Failed to get status for {torrent.title}: {e}")
+            return TorrentStatus.unknown
+
+    def _map_status(self, nzbget_status: str) -> TorrentStatus:
+        """
+        Map NZBGet queue status to TorrentStatus.
+
+        :param nzbget_status: The status from NZBGet.
+        :return: The corresponding TorrentStatus.
+        """
+        if nzbget_status in self.DOWNLOADING_STATE:
+            return TorrentStatus.downloading
+        elif nzbget_status in self.FINISHED_STATE:
+            return TorrentStatus.finished
+        elif nzbget_status in self.ERROR_STATE:
+            return TorrentStatus.error
+        else:
+            return TorrentStatus.unknown
+
+    def _map_history_status(self, history_status: str) -> TorrentStatus:
+        """
+        Map NZBGet history status to TorrentStatus.
+        History statuses are different from queue statuses.
+
+        :param history_status: The status from NZBGet history.
+        :return: The corresponding TorrentStatus.
+        """
+        # History statuses: SUCCESS, FAILURE, DELETED, etc.
+        if history_status.startswith("SUCCESS"):
+            return TorrentStatus.finished
+        elif history_status.startswith("FAILURE"):
+            return TorrentStatus.error
+        elif history_status == "DELETED":
+            return TorrentStatus.unknown
+        else:
+            return TorrentStatus.unknown

--- a/media_manager/torrent/manager.py
+++ b/media_manager/torrent/manager.py
@@ -11,6 +11,7 @@ from media_manager.torrent.download_clients.transmission import (
     TransmissionDownloadClient,
 )
 from media_manager.torrent.download_clients.sabnzbd import SabnzbdDownloadClient
+from media_manager.torrent.download_clients.nzbget import NzbgetDownloadClient
 from media_manager.torrent.schemas import Torrent, TorrentStatus
 
 log = logging.getLogger(__name__)
@@ -59,8 +60,16 @@ class DownloadManager:
             except Exception as e:
                 log.error(f"Failed to initialize Transmission client: {e}")
 
-        # Initialize SABnzbd client for usenet
-        if self.config.sabnzbd.enabled:
+        # Initialize usenet clients (prioritize NZBGet, fallback to SABnzbd)
+        if self.config.nzbget.enabled:
+            try:
+                self._usenet_client = NzbgetDownloadClient()
+                log.info("NZBGet client initialized and set as active usenet client")
+            except Exception as e:
+                log.error(f"Failed to initialize NZBGet client: {e}")
+
+        # If NZBGet is not available or failed, try SABnzbd
+        if self._usenet_client is None and self.config.sabnzbd.enabled:
             try:
                 self._usenet_client = SabnzbdDownloadClient()
                 log.info("SABnzbd client initialized and set as active usenet client")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pillow>=11.2.1",
     "pillow-avif-plugin>=1.5.2",
     "sabnzbd-api>=0.1.2",
+    "pynzbgetapi>=0.2.0",
     "transmission-rpc>=7.0.11",
     "libtorrent>=2.0.11",
 ]


### PR DESCRIPTION
Add NZBGet as an alternative to SABnzbd for usenet downloads. NZBGet is prioritized over SABnzbd when both are enabled.

- Add pynzbgetapi dependency for NZBGet API communication
- Create NzbgetConfig class with host, port, username, password settings
- Implement NzbgetDownloadClient with full AbstractDownloadClient interface
- Update DownloadManager to initialize NZBGet client
- Add configuration examples and documentation