### PR TITLE
stop saving of docker build cache when run by PRs from forks and build x86 and arm64 image in parallel

### DIFF
--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -62,13 +62,15 @@ jobs:
 
   build:
     needs: [lint-frontend, lint-backend]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/amd64
+            runner: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -84,9 +86,6 @@ jobs:
       - name: Prepare platform slug
         id: platform_slug
         run: echo "slug=${{ matrix.platform }}" | tr '/' '-' >> $GITHUB_OUTPUT
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-push-metadata_relay.yml
+++ b/.github/workflows/build-push-metadata_relay.yml
@@ -27,13 +27,15 @@ jobs:
 
   build:
     needs: lint-code
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/amd64
+            runner: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -49,9 +51,6 @@ jobs:
       - name: Prepare platform slug
         id: platform_slug
         run: echo "slug=${{ matrix.platform }}" | tr '/' '-' >> $GITHUB_OUTPUT
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This PR aims to prevent GH Workflows from failing when triggered by PRs from forks. It also aims to cut workflow runtime approximately in half, by building the x86 and arm64 image in parallel.  