### PR TITLE
fix bug where extra slash is appended to the frontend_url

### DIFF
--- a/media_manager/auth/users.py
+++ b/media_manager/auth/users.py
@@ -66,7 +66,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_forgot_password(
         self, user: User, token: str, request: Optional[Request] = None
     ):
-        link = f"{AllEncompassingConfig().misc.frontend_url}/web/login/reset-password?token={token}"
+        link = f"{AllEncompassingConfig().misc.frontend_url}web/login/reset-password?token={token}"
         log.info(f"User {user.id} has forgot their password. Reset Link: {link}")
 
         if not config.email_password_resets:
@@ -184,7 +184,7 @@ def get_jwt_strategy() -> JWTStrategy[models.UP, models.ID]:
 class RedirectingCookieTransport(CookieTransport):
     async def get_login_response(self, token: str) -> Response:
         response = RedirectResponse(
-            str(AllEncompassingConfig().misc.frontend_url) + "/web/dashboard",
+            str(AllEncompassingConfig().misc.frontend_url) + "web/dashboard",
             status_code=status.HTTP_302_FOUND,
         )
         return self._set_login_cookie(response, token)

--- a/media_manager/config.py
+++ b/media_manager/config.py
@@ -41,7 +41,7 @@ class BasicConfig(BaseSettings):
     movie_directory: Path = Path(__file__).parent.parent / "data" / "movies"
     torrent_directory: Path = Path(__file__).parent.parent / "data" / "torrents"
 
-    frontend_url: AnyHttpUrl = "http://localhost:3000"
+    frontend_url: AnyHttpUrl = "http://localhost:8000"
     cors_urls: list[str] = []
     development: bool = False
 


### PR DESCRIPTION
This pr fixes a bug that causes OAuth to not work.

The bug fixes that the user is redirected to e.g. https://example.com//web/dashboard as opposed to https://example.com/web/dashboard