### PR TITLE
Fix "new version available" card to always be displayed

### DIFF
--- a/web/src/lib/components/stats/stat-cards.svelte
+++ b/web/src/lib/components/stats/stat-cards.svelte
@@ -11,7 +11,7 @@
 	let episodeCount: string | null = $state(null);
 	let showCount: string | null = $state(null);
 	let torrentCount: string | null = $state(null);
-	let installedVersion: string | undefined = env.PUBLIC_VERSION;
+	let installedVersion: string | undefined = env.PUBLIC_VERSION?.replace(/v*/, '');
 	let releaseUrl: string | null = $state(null);
 	let newestVersion: string | null = $state(null);
 


### PR DESCRIPTION
the VERSION env variable is populated with values like "vX.Y.Z", the leading v caused the function for comparing semver versions to always output true, which causes the "new version available" card to always be active.