### PR TITLE
Remove adult search results

### DIFF
--- a/metadata_relay/app/tmdb.py
+++ b/metadata_relay/app/tmdb.py
@@ -21,7 +21,7 @@ else:
 
     @router.get("/tv/search")
     async def search_tmdb_tv(query: str, page: int = 1):
-        return Search().tv(page=page, query=query, include_adult=True)
+        return Search().tv(page=page, query=query)
 
     @router.get("/tv/shows/{show_id}")
     async def get_tmdb_show(show_id: int):
@@ -37,7 +37,7 @@ else:
 
     @router.get("/movies/search")
     async def search_tmdb_movies(query: str, page: int = 1):
-        return Search().movie(page=page, query=query, include_adult=True)
+        return Search().movie(page=page, query=query)
 
     @router.get("/movies/{movie_id}")
     async def get_tmdb_movie(movie_id: int):


### PR DESCRIPTION
This PR removes include_adult from the relay. If adult search results becomes a requested feature, support can be added with a  dedicated setting. Until then its probably best to leave search results SFW as mentioned in #258.