### PR TITLE
Fix torrent deletion logic

### DIFF
--- a/media_manager/torrent/router.py
+++ b/media_manager/torrent/router.py
@@ -40,10 +40,11 @@ def delete_torrent(
     torrent: torrent_dep,
     delete_files: bool = False,
 ):
-    try:
-        service.cancel_download(torrent=torrent, delete_files=delete_files)
-    except RuntimeError:
-        pass
+    if delete_files:
+        try:
+            service.cancel_download(torrent=torrent, delete_files=False)
+        except RuntimeError:
+            pass
 
     service.delete_torrent(torrent_id=torrent.id)
 


### PR DESCRIPTION
This pull request makes a small change to the `delete_torrent` function to ensure that when deleting torrents with the `delete_files` flag set to false, torrents won't be deleted from the download client.