### PR TITLE
fix: extract version number without 'v' 

### DIFF
--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -185,6 +185,8 @@ jobs:
             VERSION="dev-${DATE_STAMP}-${{ github.run_number }}"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION_NO_V=${VERSION#v}
+          echo "version_no_v=$VERSION_NO_V" >> $GITHUB_OUTPUT
 
       - name: Extract metadata (tags)
         id: meta
@@ -209,4 +211,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ steps.repo_name.outputs.name }}/mediamanager:${{ steps.version.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ steps.repo_name.outputs.name }}/mediamanager:${{ steps.version.outputs.version_no_v }}

--- a/.github/workflows/build-push-metadata_relay.yml
+++ b/.github/workflows/build-push-metadata_relay.yml
@@ -149,6 +149,8 @@ jobs:
             VERSION="dev-${DATE_STAMP}-${{ github.run_number }}"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION_NO_V=${VERSION#v}
+          echo "version_no_v=$VERSION_NO_V" >> $GITHUB_OUTPUT
 
       - name: Extract metadata (tags)
         id: meta
@@ -173,4 +175,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ steps.repo_name.outputs.name }}/metadata_relay:${{ steps.version.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ steps.repo_name.outputs.name }}/metadata_relay:${{ steps.version.outputs.version_no_v }}


### PR DESCRIPTION
Fix: extract version number without 'v' prefix in build workflows in order to use correct image tag for inspecting the image later in the workflow