### PR TITLE
fix: allow container to run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,23 @@ RUN locale-gen
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
+# Create a non-root user and group
+RUN groupadd -g 1000 mediamanager && \
+    useradd -m -u 1000 -g mediamanager mediamanager
+
 FROM base AS dependencies
 WORKDIR /app
+# Ensure mediamanager owns /app
+RUN chown mediamanager:mediamanager /app
 
-COPY pyproject.toml uv.lock ./
-RUN --mount=type=cache,target=/root/.cache/uv \
+USER mediamanager
+
+# Set uv cache to a writable home directory and use copy mode for volume compatibility
+ENV UV_CACHE_DIR=/home/mediamanager/.cache/uv \
+    UV_LINK_MODE=copy
+
+COPY --chown=mediamanager:mediamanager pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/home/mediamanager/.cache/uv,uid=1000,gid=1000 \
     uv sync --locked
 
 FROM dependencies AS app
@@ -37,19 +49,19 @@ LABEL version=${VERSION}
 LABEL description="Docker image for MediaManager"
 
 ENV PUBLIC_VERSION=${VERSION} \
-    CONFIG_DIR="/app/config"\
-    BASE_PATH=${BASE_PATH}\
+    CONFIG_DIR="/app/config" \
+    BASE_PATH=${BASE_PATH} \
     FRONTEND_FILES_DIR="/app/web/build"
 
-COPY --chmod=755 mediamanager-startup.sh .
-COPY config.example.toml .
-COPY media_manager ./media_manager
-COPY alembic ./alembic
-COPY alembic.ini .
+COPY --chown=mediamanager:mediamanager --chmod=755 mediamanager-startup.sh .
+COPY --chown=mediamanager:mediamanager config.example.toml .
+COPY --chown=mediamanager:mediamanager media_manager ./media_manager
+COPY --chown=mediamanager:mediamanager alembic ./alembic
+COPY --chown=mediamanager:mediamanager alembic.ini .
 
 HEALTHCHECK CMD curl -f http://localhost:8000${BASE_PATH}/api/v1/health || exit 1
 EXPOSE 8000
 CMD ["/app/mediamanager-startup.sh"]
 
 FROM app AS production
-COPY --from=frontend-build /frontend/build /app/web/build
+COPY --chown=mediamanager:mediamanager --from=frontend-build /frontend/build /app/web/build

--- a/metadata_relay/Dockerfile
+++ b/metadata_relay/Dockerfile
@@ -4,11 +4,27 @@ LABEL version=${VERSION}
 
 ENV BASE_PATH=""
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
+# Create a non-root user and group
+RUN groupadd -g 1000 mediamanager && \
+    useradd -m -u 1000 -g mediamanager mediamanager
 
 WORKDIR /app
-COPY . .
-RUN uv sync --locked
+# Ensure mediamanager owns the app directory
+RUN chown mediamanager:mediamanager /app
+
+USER mediamanager
+
+# Set uv cache to a writable home directory and use copy mode for volume compatibility
+ENV UV_CACHE_DIR=/home/mediamanager/.cache/uv \
+    UV_LINK_MODE=copy
+
+COPY --chown=mediamanager:mediamanager . .
+RUN --mount=type=cache,target=/home/mediamanager/.cache/uv,uid=1000,gid=1000 \
+    uv sync --locked
+
 EXPOSE 8000
 CMD ["uv", "run", "fastapi", "run", "/app/main.py"]


### PR DESCRIPTION
- Create mediamanager user and group (UID/GID 1000)
- Set ownership of /app and /data to mediamanager
- Configure uv to use writable cache directory in home
- Set UV_LINK_MODE=copy for better compatibility
- Closes #96