### PR TITLE
push docker images to quay.io as well

### DIFF
--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -225,7 +225,9 @@ jobs:
           mapfile -t TAGS <<< "${{ steps.meta.outputs.tags }}"
           for TAG in "${TAGS[@]}"; do
             docker buildx imagetools create \
-              --tag "${TAG}"
+              --tag "${TAG}" \
+              "${TAG}-amd64" \
+              "${TAG}-arm64"
           done
 
       - name: Inspect image (GHCR)

--- a/.github/workflows/build-push-metadata_relay.yml
+++ b/.github/workflows/build-push-metadata_relay.yml
@@ -189,7 +189,9 @@ jobs:
           mapfile -t TAGS <<< "${{ steps.meta.outputs.tags }}"
           for TAG in "${TAGS[@]}"; do
             docker buildx imagetools create \
-              --tag "${TAG}"
+              --tag "${TAG}" \
+              "${TAG}-amd64" \
+              "${TAG}-arm64"
           done
 
       - name: Inspect image (GHCR)


### PR DESCRIPTION
This PR adjusts the GH Workflows to also push the container images to quay.io.

## motivation

Pulling from GHCR is extremely slow and GH doesn't seem to fix it.

See https://github.com/orgs/community/discussions/173607

Pulling images takes upwards of 10min even though my internet connections would allow for faster download speeds.

```
docker compose pull mediamanager
[+] Pulling 20/20
 ✔ mediamanager Pulled                                             450.7s 
```

Pulling the same image from quay takes less than a minute.