### PR TITLE
fix build workflows

### DIFF
--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -75,7 +75,7 @@ jobs:
       contents: read
       packages:  write
     env:
-      QUAY_ORG: ${{ secrets.QUAY_ORG }}
+      QUAY_ORG: ${{ secrets.QUAY_ORG || github.repository_owner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-push-metadata_relay.yml
+++ b/.github/workflows/build-push-metadata_relay.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       packages:  write
     env:
-      QUAY_ORG: ${{ secrets.QUAY_ORG }}
+      QUAY_ORG: ${{ secrets.QUAY_ORG || github.repository_owner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
       contents: read
       packages: write
     env:
-      QUAY_ORG: ${{ secrets.QUAY_ORG }}
+      QUAY_ORG: ${{ secrets.QUAY_ORG || github.repository_owner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
this PR fixes the build workflows, so the QUAY_ORG environment variable is populated even when run by a PR from a fork