### PR TITLE
Fix logging bug in jackett indexer

### DIFF
--- a/media_manager/indexer/indexers/jackett.py
+++ b/media_manager/indexer/indexers/jackett.py
@@ -67,7 +67,7 @@ class Jackett(GenericIndexer, TorznabMixin):
 
         results = self.process_search_result(response.content)
 
-        log.info(f"Indexer {indexer.name} returned {len(results)} results")
+        log.info(f"Indexer {indexer} returned {len(results)} results")
         return results
 
     def search_season(


### PR DESCRIPTION
Hi! This is a really cool project. I tried setting it up, but encountered errors using Jackett as an indexer. Apparently it's simply a mistake in this logging line. The Jackett logs seem OK, but I see this in the MediaManager logs:

```
2026-01-06 10:57:00,360 - ERROR - media_manager.indexer.indexers.jackett - search(): search result failed with: 'str' object has no attribute 'name'
2026-01-06 10:57:00,361 - DEBUG - media_manager.indexer.service - search(): Indexer Jackett returned 0 results for query: ...
```

I tested a local build and this works.