### PR TITLE
Add flag to disable startup ascii art

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,6 +22,7 @@
   * [Metadata Provider Configuration](advanced-features/metadata-provider-configuration.md)
   * [Custom port](advanced-features/custom-port.md)
   * [Follow symlinks in frontend files](advanced-features/follow-symlinks-in-frontend-files.md)
+  * [Disable startup ascii art](advanced-featured/disable-startup-ascii-art.md)
 * [Troubleshooting](troubleshooting.md)
 * [API Reference](api-reference.md)
 * [Screenshots](screenshots.md)

--- a/docs/advanced-features/disable-startup-ascii-art.md
+++ b/docs/advanced-features/disable-startup-ascii-art.md
@@ -1,0 +1,4 @@
+# Disable Startup Ascii Art
+
+* `MEDIAMANAGER_NO_STARTUP_ART`: Set this environment variable (to any value) \
+  to disable the colorized startup splash screen. Unset to reenable.

--- a/mediamanager-startup.sh
+++ b/mediamanager-startup.sh
@@ -104,7 +104,16 @@ ASCII_ART='
                                                 ░░░░░░
 
 '
-display_cool_text "$ASCII_ART"
+if [[ -v MEDIAMANAGER_NO_STARTUP_ART ]]; then
+  echo
+  echo "   +================+"
+  echo "   |  MediaManager  |"
+  echo "   +================+"
+  echo
+else
+  display_cool_text "$ASCII_ART"
+fi
+
 echo "Buy me a coffee at https://buymeacoffee.com/maxdorninger"
 
 # Initialize config if it doesn't exist


### PR DESCRIPTION
Adds an environment variable to disable the colorized splash screen. Resolves #348 