### PR TITLE
Fix bug by typo in jackett log message

### DIFF
--- a/media_manager/indexer/indexers/jackett.py
+++ b/media_manager/indexer/indexers/jackett.py
@@ -74,7 +74,7 @@ class Jackett(GenericIndexer, TorznabMixin):
     def search_season(
         self, query: str, show: Show, season_number: int
     ) -> list[IndexerQueryResult]:
-        log.debug(f"Searching for season {season_number} of show {show.title}")
+        log.debug(f"Searching for season {season_number} of show {show.name}")
         return self.search(query=query, is_tv=True)
 
     def search_movie(self, query: str, movie: Movie) -> list[IndexerQueryResult]:


### PR DESCRIPTION
Hi Max

I found a little typo in the `search_season` function log, which causes an error when searching for torrents.