### PR TITLE
Fix download clients config being read from env variables

### DIFF
--- a/media_manager/torrent/config.py
+++ b/media_manager/torrent/config.py
@@ -1,8 +1,7 @@
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings
 
 
 class QbittorrentConfig(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="QBITTORRENT_")
     host: str = "localhost"
     port: int = 8080
     username: str = "admin"
@@ -14,7 +13,6 @@ class QbittorrentConfig(BaseSettings):
 
 
 class TransmissionConfig(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="TRANSMISSION_")
     path: str = "/transmission/rpc"
     https_enabled: bool = True
     host: str = "localhost"
@@ -25,7 +23,6 @@ class TransmissionConfig(BaseSettings):
 
 
 class SabnzbdConfig(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="SABNZBD_")
     host: str = "localhost"
     port: int = 8080
     api_key: str = ""


### PR DESCRIPTION
this PR fixes the download client's config being read from env variables without the mediamanager prefix.

The cause was that the reading the config from env variables was still enabled, the solution is to simply remove the SettingsConfigDict.
```diff
class QbittorrentConfig(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="QBITTORRENT_")
    ...
```