### PR TITLE
Fix suffix formatting for with_suffix call

### DIFF
--- a/media_manager/metadataProvider/utils.py
+++ b/media_manager/metadataProvider/utils.py
@@ -15,7 +15,7 @@ def download_poster_image(storage_path: Path, poster_url: str, uuid: UUID) -> bo
     res = requests.get(poster_url, stream=True, timeout=60)
 
     if res.status_code == 200:
-        image_file_path = storage_path.joinpath(str(uuid)).with_suffix("jpg")
+        image_file_path = storage_path.joinpath(str(uuid)).with_suffix(".jpg")
         image_file_path.write_bytes(res.content)
 
         original_image = Image.open(image_file_path)


### PR DESCRIPTION
Fixes issue ValueError: Invalid suffix 'jpg'

Completely prevents downloading posters from metadata provider