### PR TITLE
Fix qbittorrent category error

### DIFF
--- a/media_manager/torrent/download_clients/qbittorrent.py
+++ b/media_manager/torrent/download_clients/qbittorrent.py
@@ -60,9 +60,7 @@ class QbittorrentDownloadClient(AbstractDownloadClient):
         try:
             self.api_client.torrents_create_category(
                 name=self.config.category_name,
-                save_path=self.config.category_save_path
-                if self.config.category_save_path != ""
-                else None,
+                save_path=self.config.category_save_path,
             )
         except Conflict409Error:
             try:


### PR DESCRIPTION
This PR fixes an error caused by MM trying to set the category save path to None if the string is empty.