### PR TITLE
Extend AVOID_CAM scoring rule

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -138,7 +138,7 @@ negate = false
 
 [[indexers.title_scoring_rules]]
 name = "avoid_cam"
-keywords = ["cam", "ts"]
+keywords = ["cam", "camrip", "bdscr", "ddc", "dvdscreener","dvdscr", "hdcam", "hdtc", "hdts", "scr", "screener","telesync", "ts", "webscreener", "tc", "telecine", "tvrip"]
 score_modifier = -10000
 negate = false
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -138,7 +138,7 @@ negate = false
 
 [[indexers.title_scoring_rules]]
 name = "avoid_cam"
-keywords = ["cam", "ts"]
+keywords = ["cam", "camrip", "bdscr", "ddc", "dvdscreener","dvdscr", "hdcam", "hdtc", "hdts", "scr", "screener","telesync", "ts", "webscreener", "tc", "telecine", "tvrip"]
 score_modifier = -10000
 negate = false
 


### PR DESCRIPTION
The base title scoring rule **avoid_cam** can be extended with more keyword related to low quality videos similar to CAM.


| Type      | Acronyms                                                                | Meaning                                                                                                                                                                |
|-----------|-------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| CAM       | CAM<br>CAMRIP<br>HDCAM                                                  | A recording made with a handheld camera in a movie theater.                                                                                                            |
| Screener  | BDSCR<br>DDC<br>DVDSCR<br>DVDSCREENER<br>SCR<br>SCREENER<br>WEBSCREENER | Screeners are early DVD or BD releases of the theatrical version of a film, typically sent to movie reviewers, academy members and executives for review purposes.     |
| Telecine  | HDTC<br>TC<br>TELECINE                                                  | A digital scan of the film print.                                                                                                                                      |
| Telesync  | HDTS<br>TELESYNC<br>TS                                                  | Similar to *CAM*, but the camera is typically placed closer to the projector or on a tripod in the projection booth. Audio is captured directly from the sound system. |
| TV        | TVRIP                                                                   |                                                                                                                                                                        

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved detection of additional camera-related content format variants through updated filtering rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->