### PR TITLE
Use openapi schemas directly

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "eslint --concurrency auto --fix . && prettier --check .",
 		"format": "prettier --write .",
-		"openapi": "npx openapi-typescript http://localhost:8000/openapi.json -o src/lib/api/api.d.ts"
+		"openapi": "npx openapi-typescript http://localhost:8000/openapi.json --root-types --root-types-no-schema-prefix -o src/lib/api/api.d.ts"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^2.0.2",

--- a/web/src/lib/api/api.d.ts
+++ b/web/src/lib/api/api.d.ts
@@ -1718,6 +1718,49 @@ export interface components {
 	headers: never;
 	pathItems: never;
 }
+export type AuthMetadata = components['schemas']['AuthMetadata'];
+export type BearerResponse = components['schemas']['BearerResponse'];
+export type BodyAuthCookieLoginApiV1AuthCookieLoginPost =
+	components['schemas']['Body_auth_cookie_login_api_v1_auth_cookie_login_post'];
+export type BodyAuthJwtLoginApiV1AuthJwtLoginPost =
+	components['schemas']['Body_auth_jwt_login_api_v1_auth_jwt_login_post'];
+export type BodyResetForgotPasswordApiV1AuthForgotPasswordPost =
+	components['schemas']['Body_reset_forgot_password_api_v1_auth_forgot_password_post'];
+export type BodyResetResetPasswordApiV1AuthResetPasswordPost =
+	components['schemas']['Body_reset_reset_password_api_v1_auth_reset_password_post'];
+export type BodyVerifyRequestTokenApiV1AuthRequestVerifyTokenPost =
+	components['schemas']['Body_verify_request_token_api_v1_auth_request_verify_token_post'];
+export type BodyVerifyVerifyApiV1AuthVerifyPost =
+	components['schemas']['Body_verify_verify_api_v1_auth_verify_post'];
+export type Episode = components['schemas']['Episode'];
+export type ErrorModel = components['schemas']['ErrorModel'];
+export type HttpValidationError = components['schemas']['HTTPValidationError'];
+export type IndexerQueryResult = components['schemas']['IndexerQueryResult'];
+export type LibraryItem = components['schemas']['LibraryItem'];
+export type MediaImportSuggestion = components['schemas']['MediaImportSuggestion'];
+export type MetaDataProviderSearchResult = components['schemas']['MetaDataProviderSearchResult'];
+export type Movie = components['schemas']['Movie'];
+export type MovieTorrent = components['schemas']['MovieTorrent'];
+export type Notification = components['schemas']['Notification'];
+export type OAuth2AuthorizeResponse = components['schemas']['OAuth2AuthorizeResponse'];
+export type PublicEpisode = components['schemas']['PublicEpisode'];
+export type PublicEpisodeFile = components['schemas']['PublicEpisodeFile'];
+export type PublicMovie = components['schemas']['PublicMovie'];
+export type PublicMovieFile = components['schemas']['PublicMovieFile'];
+export type PublicSeason = components['schemas']['PublicSeason'];
+export type PublicShow = components['schemas']['PublicShow'];
+export type Quality = components['schemas']['Quality'];
+export type RichMovieTorrent = components['schemas']['RichMovieTorrent'];
+export type RichSeasonTorrent = components['schemas']['RichSeasonTorrent'];
+export type RichShowTorrent = components['schemas']['RichShowTorrent'];
+export type Season = components['schemas']['Season'];
+export type Show = components['schemas']['Show'];
+export type Torrent = components['schemas']['Torrent'];
+export type TorrentStatus = components['schemas']['TorrentStatus'];
+export type UserCreate = components['schemas']['UserCreate'];
+export type UserRead = components['schemas']['UserRead'];
+export type UserUpdate = components['schemas']['UserUpdate'];
+export type ValidationError = components['schemas']['ValidationError'];
 export type $defs = Record<string, never>;
 export interface operations {
 	hello_world_api_v1_health_get: {

--- a/web/src/lib/components/add-media-card.svelte
+++ b/web/src/lib/components/add-media-card.svelte
@@ -4,15 +4,13 @@
 	import { ImageOff, LoaderCircle } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import type { components } from '$lib/api/api';
+	import type { MetaDataProviderSearchResult } from '$lib/api/api';
 	import client from '$lib/api';
 
 	let loading = $state(false);
 	let errorMessage = $state<string | null>(null);
-	let {
-		result,
-		isShow = true
-	}: { result: components['schemas']['MetaDataProviderSearchResult']; isShow: boolean } = $props();
+	let { result, isShow = true }: { result: MetaDataProviderSearchResult; isShow: boolean } =
+		$props();
 
 	async function addMedia() {
 		loading = true;

--- a/web/src/lib/components/delete-media-dialog.svelte
+++ b/web/src/lib/components/delete-media-dialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { components } from '$lib/api/api.ts';
+	import type { PublicMovie, PublicShow } from '$lib/api/api.ts';
 	import { toast } from 'svelte-sonner';
 	import client from '$lib/api/index.ts';
 	import { goto } from '$app/navigation';
@@ -14,7 +14,7 @@
 		media,
 		isShow
 	}: {
-		media: components['schemas']['PublicMovie'] | components['schemas']['PublicShow'];
+		media: PublicMovie | PublicShow;
 		isShow: boolean;
 	} = $props();
 	let deleteDialogOpen = $state(false);

--- a/web/src/lib/components/download-dialogs/download-custom-dialog.svelte
+++ b/web/src/lib/components/download-dialogs/download-custom-dialog.svelte
@@ -7,14 +7,14 @@
 	import * as Table from '$lib/components/ui/table';
 	import { Badge } from '$lib/components/ui/badge';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { Show } from '$lib/api/api';
 	import SelectFilePathSuffixDialog from '$lib/components/download-dialogs/select-file-path-suffix-dialog.svelte';
 	import { invalidateAll } from '$app/navigation';
 	import TorrentTable from '$lib/components/download-dialogs/torrent-table.svelte';
 	import DownloadDialogWrapper from '$lib/components/download-dialogs/download-dialog-wrapper.svelte';
 	import { getFullyQualifiedMediaName } from '$lib/utils';
 
-	let { show }: { show: components['schemas']['Show'] } = $props();
+	let { show }: { show: Show } = $props();
 
 	let dialogueState = $state(false);
 	let torrentsError: string | null = $state(null);

--- a/web/src/lib/components/download-dialogs/download-movie-dialog.svelte
+++ b/web/src/lib/components/download-dialogs/download-movie-dialog.svelte
@@ -5,14 +5,14 @@
 
 	import * as Table from '$lib/components/ui/table';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { Movie } from '$lib/api/api';
 	import SelectFilePathSuffixDialog from '$lib/components/download-dialogs/select-file-path-suffix-dialog.svelte';
 	import { invalidateAll } from '$app/navigation';
 	import TorrentTable from '$lib/components/download-dialogs/torrent-table.svelte';
 	import SearchTabs from '$lib/components/download-dialogs/search-tabs.svelte';
 	import DownloadDialogWrapper from '$lib/components/download-dialogs/download-dialog-wrapper.svelte';
 
-	let { movie }: { movie: components['schemas']['Movie'] } = $props();
+	let { movie }: { movie: Movie } = $props();
 	let dialogueState = $state(false);
 	let torrentsError: string | null = $state(null);
 	let queryOverride: string = $state('');

--- a/web/src/lib/components/download-dialogs/download-season-dialog.svelte
+++ b/web/src/lib/components/download-dialogs/download-season-dialog.svelte
@@ -10,14 +10,14 @@
 	import * as Table from '$lib/components/ui/table';
 	import { Badge } from '$lib/components/ui/badge';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { Show } from '$lib/api/api';
 	import SelectFilePathSuffixDialog from '$lib/components/download-dialogs/select-file-path-suffix-dialog.svelte';
 	import { invalidateAll } from '$app/navigation';
 	import TorrentTable from '$lib/components/download-dialogs/torrent-table.svelte';
 	import SearchTabs from '$lib/components/download-dialogs/search-tabs.svelte';
 	import DownloadDialogWrapper from '$lib/components/download-dialogs/download-dialog-wrapper.svelte';
 
-	let { show }: { show: components['schemas']['Show'] } = $props();
+	let { show }: { show: Show } = $props();
 	let dialogueState = $state(false);
 	let selectedSeasonNumber: number = $state(1);
 	let torrentsError: string | null = $state(null);

--- a/web/src/lib/components/download-dialogs/download-selected-episodes-dialog.svelte
+++ b/web/src/lib/components/download-dialogs/download-selected-episodes-dialog.svelte
@@ -5,7 +5,7 @@
 	import * as Table from '$lib/components/ui/table';
 	import { Badge } from '$lib/components/ui/badge';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { Show } from '$lib/api/api';
 	import SelectFilePathSuffixDialog from '$lib/components/download-dialogs/select-file-path-suffix-dialog.svelte';
 	import { invalidateAll } from '$app/navigation';
 	import TorrentTable from '$lib/components/download-dialogs/torrent-table.svelte';
@@ -16,7 +16,7 @@
 		selectedEpisodeNumbers,
 		triggerText = 'Download Episodes'
 	}: {
-		show: components['schemas']['Show'];
+		show: Show;
 		selectedEpisodeNumbers: { seasonNumber: number; episodeNumber: number }[];
 		triggerText?: string;
 	} = $props();

--- a/web/src/lib/components/download-dialogs/download-selected-seasons-dialog.svelte
+++ b/web/src/lib/components/download-dialogs/download-selected-seasons-dialog.svelte
@@ -5,7 +5,7 @@
 	import * as Table from '$lib/components/ui/table';
 	import { Badge } from '$lib/components/ui/badge';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { Show } from '$lib/api/api';
 	import SelectFilePathSuffixDialog from '$lib/components/download-dialogs/select-file-path-suffix-dialog.svelte';
 	import { invalidateAll } from '$app/navigation';
 	import TorrentTable from '$lib/components/download-dialogs/torrent-table.svelte';
@@ -16,7 +16,7 @@
 		selectedSeasonNumbers,
 		triggerText = 'Download Selected Seasons'
 	}: {
-		show: components['schemas']['Show'];
+		show: Show;
 		selectedSeasonNumbers: number[];
 		triggerText?: string;
 	} = $props();

--- a/web/src/lib/components/download-dialogs/file-path-suffix-selector.svelte
+++ b/web/src/lib/components/download-dialogs/file-path-suffix-selector.svelte
@@ -2,7 +2,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
 	import { saveDirectoryPreview } from '$lib/utils.js';
-	import type { components } from '$lib/api/api';
+	import type { Movie, Show } from '$lib/api/api';
 	import * as Tabs from '$lib/components/ui/tabs';
 
 	import { Input } from '$lib/components/ui/input';
@@ -10,7 +10,7 @@
 		media,
 		filePathSuffix = $bindable()
 	}: {
-		media: components['schemas']['Movie'] | components['schemas']['Show'];
+		media: Movie | Show;
 		filePathSuffix: string;
 	} = $props();
 </script>

--- a/web/src/lib/components/download-dialogs/select-file-path-suffix-dialog.svelte
+++ b/web/src/lib/components/download-dialogs/select-file-path-suffix-dialog.svelte
@@ -2,7 +2,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import FilePathSuffixSelector from '$lib/components/download-dialogs/file-path-suffix-selector.svelte';
-	import type { components } from '$lib/api/api';
+	import type { Movie, Show } from '$lib/api/api';
 
 	let {
 		filePathSuffix = $bindable(),
@@ -10,7 +10,7 @@
 		callback
 	}: {
 		filePathSuffix: string;
-		media: components['schemas']['Movie'] | components['schemas']['Show'];
+		media: Movie | Show;
 		callback: () => void;
 	} = $props();
 	let dialogOpen = $state(false);

--- a/web/src/lib/components/import-media/import-candidates-dialog.svelte
+++ b/web/src/lib/components/import-media/import-candidates-dialog.svelte
@@ -3,7 +3,7 @@
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
 	import { toast } from 'svelte-sonner';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { MetaDataProviderSearchResult } from '$lib/api/api';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import SuggestedMediaCard from '$lib/components/import-media/suggested-media-card.svelte';
 	import { invalidateAll } from '$app/navigation';
@@ -16,14 +16,14 @@
 	}: {
 		isTv: boolean;
 		name: string;
-		candidates: components['schemas']['MetaDataProviderSearchResult'][];
+		candidates: MetaDataProviderSearchResult[];
 		children: any;
 	} = $props();
 	let dialogOpen = $state(false);
 	let submitRequestError = $state<string | null>(null);
 	let isImporting = $state<boolean>(false);
 
-	async function handleImportMedia(media: components['schemas']['MetaDataProviderSearchResult']) {
+	async function handleImportMedia(media: MetaDataProviderSearchResult) {
 		isImporting = true;
 		submitRequestError = null;
 		let errored = null;

--- a/web/src/lib/components/import-media/suggested-media-card.svelte
+++ b/web/src/lib/components/import-media/suggested-media-card.svelte
@@ -2,13 +2,13 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { ImageOff } from 'lucide-svelte';
-	import type { components } from '$lib/api/api';
+	import type { MetaDataProviderSearchResult } from '$lib/api/api';
 
 	let {
 		result,
 		action
 	}: {
-		result: components['schemas']['MetaDataProviderSearchResult'];
+		result: MetaDataProviderSearchResult;
 		action: () => void;
 	} = $props();
 </script>

--- a/web/src/lib/components/library-combobox.svelte
+++ b/web/src/lib/components/library-combobox.svelte
@@ -8,20 +8,20 @@
 	import { onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { PublicShow, PublicMovie, LibraryItem } from '$lib/api/api';
 	import { invalidateAll } from '$app/navigation';
 
 	let {
 		media,
 		mediaType
 	}: {
-		media: components['schemas']['PublicShow'] | components['schemas']['PublicMovie'];
+		media: PublicShow | PublicMovie;
 		mediaType: 'tv' | 'movie';
 	} = $props();
 
 	let open = $state(false);
 	let value = $derived(media.library === '' ? 'Default' : media.library);
-	let libraries: components['schemas']['LibraryItem'][] = $state([]);
+	let libraries: LibraryItem[] = $state([]);
 	let triggerRef: HTMLButtonElement = $state(null!);
 	const selectedLabel: string = $derived(
 		libraries.find((item) => item.name === value)?.name ?? 'Default'
@@ -31,9 +31,9 @@
 		const movieLibraries = await client.GET('/api/v1/movies/libraries');
 
 		if (mediaType === 'tv') {
-			libraries = tvLibraries.data as components['schemas']['LibraryItem'][];
+			libraries = tvLibraries.data as LibraryItem[];
 		} else {
-			libraries = movieLibraries.data as components['schemas']['LibraryItem'][];
+			libraries = movieLibraries.data as LibraryItem[];
 		}
 
 		if (!value && libraries.length > 0) {
@@ -42,7 +42,7 @@
 		libraries.push({
 			name: 'Default',
 			path: 'Default'
-		} as components['schemas']['LibraryItem']);
+		} as LibraryItem);
 	});
 
 	async function handleSelect() {

--- a/web/src/lib/components/nav/user-details.svelte
+++ b/web/src/lib/components/nav/user-details.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
-	import type { components } from '$lib/api/api';
-	const user: () => components['schemas']['UserRead'] = getContext('user');
+	import type { UserRead } from '$lib/api/api';
+	const user: () => UserRead = getContext('user');
 </script>
 
 <span class="truncate font-semibold">{user().email}</span>

--- a/web/src/lib/components/recommended-media-carousel.svelte
+++ b/web/src/lib/components/recommended-media-carousel.svelte
@@ -3,7 +3,7 @@
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import { Button } from '$lib/components/ui/button';
 	import { ChevronRight } from 'lucide-svelte';
-	import type { components } from '$lib/api/api';
+	import type { MetaDataProviderSearchResult } from '$lib/api/api';
 	import { resolve } from '$app/paths';
 
 	let {
@@ -11,7 +11,7 @@
 		isShow,
 		isLoading
 	}: {
-		media: components['schemas']['MetaDataProviderSearchResult'][];
+		media: MetaDataProviderSearchResult[];
 		isShow: boolean;
 		isLoading: boolean;
 	} = $props();

--- a/web/src/lib/components/torrents/edit-torrent-dialog.svelte
+++ b/web/src/lib/components/torrents/edit-torrent-dialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import type { components } from '$lib/api/api';
+	import type { MovieTorrent, RichSeasonTorrent } from '$lib/api/api';
 	import { Switch } from '$lib/components/ui/switch';
 	import { Label } from '$lib/components/ui/label';
 	import client from '$lib/api';
@@ -11,7 +11,7 @@
 	let {
 		torrent
 	}: {
-		torrent: components['schemas']['MovieTorrent'] | components['schemas']['RichSeasonTorrent'];
+		torrent: MovieTorrent | RichSeasonTorrent;
 	} = $props();
 	let dialogOpen = $state(false);
 	let importedState = $derived(torrent.imported);

--- a/web/src/lib/components/torrents/torrent-table.svelte
+++ b/web/src/lib/components/torrents/torrent-table.svelte
@@ -7,7 +7,7 @@
 	} from '$lib/utils.js';
 	import CheckmarkX from '$lib/components/checkmark-x.svelte';
 	import * as Table from '$lib/components/ui/table';
-	import type { components } from '$lib/api/api';
+	import type { MovieTorrent, RichSeasonTorrent, UserRead } from '$lib/api/api';
 	import { getContext } from 'svelte';
 	import { Button } from '$lib/components/ui/button';
 	import client from '$lib/api';
@@ -22,19 +22,15 @@
 		showId,
 		movieId
 	}: {
-		torrents:
-			| components['schemas']['MovieTorrent'][]
-			| components['schemas']['RichSeasonTorrent'][];
+		torrents: MovieTorrent[] | RichSeasonTorrent[];
 		isShow: boolean;
 		showId?: string;
 		movieId?: string;
 	} = $props();
 
-	let user: () => components['schemas']['UserRead'] = getContext('user');
+	let user: () => UserRead = getContext('user');
 
-	async function retryTorrentDownload(
-		torrent: components['schemas']['MovieTorrent'] | components['schemas']['RichSeasonTorrent']
-	) {
+	async function retryTorrentDownload(torrent: MovieTorrent | RichSeasonTorrent) {
 		console.log(`Retrying download for torrent ${torrent.torrent_title}`);
 		const { error } = await client.POST('/api/v1/torrent/{torrent_id}/retry', {
 			params: {
@@ -95,14 +91,10 @@
 				</Table.Cell>
 				{#if isShow}
 					<Table.Cell>
-						{convertTorrentSeasonRangeToIntegerRange(
-							(torrent as components['schemas']['RichSeasonTorrent']).seasons!
-						)}
+						{convertTorrentSeasonRangeToIntegerRange((torrent as RichSeasonTorrent).seasons!)}
 					</Table.Cell>
 					<Table.Cell>
-						{convertTorrentEpisodeRangeToIntegerRange(
-							(torrent as components['schemas']['RichSeasonTorrent']).episodes!
-						)}
+						{convertTorrentEpisodeRangeToIntegerRange((torrent as RichSeasonTorrent).episodes!)}
 					</Table.Cell>
 				{/if}
 				<Table.Cell>

--- a/web/src/lib/components/user-data-table.svelte
+++ b/web/src/lib/components/user-data-table.svelte
@@ -10,12 +10,12 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { invalidateAll } from '$app/navigation';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { UserRead } from '$lib/api/api';
 
-	let { users }: { users: components['schemas']['UserRead'][] } = $props();
+	let { users }: { users: UserRead[] } = $props();
 	let sortedUsers = $derived(users.sort((a, b) => a.email.localeCompare(b.email)));
-	let selectedUser: components['schemas']['UserRead'] | null = $state(null);
-	let userToDelete: components['schemas']['UserRead'] | null = $state(null);
+	let selectedUser: UserRead | null = $state(null);
+	let userToDelete: UserRead | null = $state(null);
 	let newPassword: string = $state('');
 	let newEmail: string = $state('');
 	let dialogOpen = $state(false);

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -4,7 +4,7 @@ import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { toast } from 'svelte-sonner';
 import client from '$lib/api';
-import type { components } from '$lib/api/api';
+import type { Show, Movie } from '$lib/api/api';
 
 export const qualityMap: { [key: number]: string } = {
 	1: '4K/UHD',
@@ -110,10 +110,7 @@ export function handleQueryNotificationToast(count: number = 0, query: string = 
 	else if (count == 0) toast.info(`No results found for "${query}".`);
 }
 
-export function saveDirectoryPreview(
-	media: components['schemas']['Show'] | components['schemas']['Movie'],
-	filePathSuffix: string = ''
-) {
+export function saveDirectoryPreview(media: Show | Movie, filePathSuffix: string = '') {
 	let path =
 		'/' +
 		getFullyQualifiedMediaName(media) +

--- a/web/src/routes/dashboard/+layout.svelte
+++ b/web/src/routes/dashboard/+layout.svelte
@@ -7,11 +7,11 @@
 	import { resolve } from '$app/paths';
 	import { toast } from 'svelte-sonner';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { MediaImportSuggestion } from '$lib/api/api';
 
 	let { data, children }: LayoutProps = $props();
-	let importableShows: components['schemas']['MediaImportSuggestion'][] = $state([]);
-	let importableMovies: components['schemas']['MediaImportSuggestion'][] = $state([]);
+	let importableShows: MediaImportSuggestion[] = $state([]);
+	let importableMovies: MediaImportSuggestion[] = $state([]);
 	setContext('user', () => data.user);
 	setContext('importableMovies', () => importableMovies);
 	setContext('importableShows', () => importableShows);

--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -7,22 +7,22 @@
 	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api.d.ts';
+	import type { MetaDataProviderSearchResult } from '$lib/api/api.d.ts';
 	import type { PageProps } from './$types';
 	let { data }: PageProps = $props();
-	let recommendedShows: components['schemas']['MetaDataProviderSearchResult'][] = $state([]);
+	let recommendedShows: MetaDataProviderSearchResult[] = $state([]);
 	let showsLoading = $state(true);
 
-	let recommendedMovies: components['schemas']['MetaDataProviderSearchResult'][] = $state([]);
+	let recommendedMovies: MetaDataProviderSearchResult[] = $state([]);
 	let moviesLoading = $state(true);
 
 	onMount(async () => {
 		client.GET('/api/v1/tv/recommended').then((res) => {
-			recommendedShows = res.data as components['schemas']['MetaDataProviderSearchResult'][];
+			recommendedShows = res.data as MetaDataProviderSearchResult[];
 			showsLoading = false;
 		});
 		client.GET('/api/v1/movies/recommended').then((res) => {
-			recommendedMovies = res.data as components['schemas']['MetaDataProviderSearchResult'][];
+			recommendedMovies = res.data as MetaDataProviderSearchResult[];
 			moviesLoading = false;
 		});
 	});

--- a/web/src/routes/dashboard/movies/+page.svelte
+++ b/web/src/routes/dashboard/movies/+page.svelte
@@ -6,7 +6,7 @@
 	import { getFullyQualifiedMediaName } from '$lib/utils';
 	import MediaPicture from '$lib/components/media-picture.svelte';
 	import { resolve } from '$app/paths';
-	import type { MediaImportSuggestion } from '$lib/api/api.d.ts';
+	import type { MediaImportSuggestion } from '$lib/api/api';
 	import ImportCandidatesDialog from '$lib/components/import-media/import-candidates-dialog.svelte';
 	import DetectedMediaCard from '$lib/components/import-media/detected-media-card.svelte';
 	import { getContext } from 'svelte';

--- a/web/src/routes/dashboard/movies/+page.svelte
+++ b/web/src/routes/dashboard/movies/+page.svelte
@@ -6,7 +6,7 @@
 	import { getFullyQualifiedMediaName } from '$lib/utils';
 	import MediaPicture from '$lib/components/media-picture.svelte';
 	import { resolve } from '$app/paths';
-	import type { components } from '$lib/api/api.d.ts';
+	import type { MediaImportSuggestion } from '$lib/api/api.d.ts';
 	import ImportCandidatesDialog from '$lib/components/import-media/import-candidates-dialog.svelte';
 	import DetectedMediaCard from '$lib/components/import-media/detected-media-card.svelte';
 	import { getContext } from 'svelte';
@@ -14,8 +14,7 @@
 	import LoadingBar from '$lib/components/loading-bar.svelte';
 
 	let { data }: PageProps = $props();
-	let importableMovies: () => components['schemas']['MediaImportSuggestion'][] =
-		getContext('importableMovies');
+	let importableMovies: () => MediaImportSuggestion[] = getContext('importableMovies');
 </script>
 
 <svelte:head>

--- a/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/movies/[movieId=uuid]/+page.svelte
@@ -5,7 +5,7 @@
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { ImageOff } from 'lucide-svelte';
 	import { getContext } from 'svelte';
-	import type { components } from '$lib/api/api';
+	import type { PublicMovie, PublicMovieFile, UserRead } from '$lib/api/api';
 	import { getFullyQualifiedMediaName, getTorrentQualityString } from '$lib/utils';
 	import { page } from '$app/state';
 	import TorrentTable from '$lib/components/torrents/torrent-table.svelte';
@@ -17,9 +17,9 @@
 	import DeleteMediaDialog from '$lib/components/delete-media-dialog.svelte';
 	import CheckmarkX from '$lib/components/checkmark-x.svelte';
 
-	let movie: components['schemas']['PublicMovie'] = $derived(page.data.movie);
-	let movieFiles: components['schemas']['PublicMovieFile'][] = $derived(page.data.movieFiles);
-	let user: () => components['schemas']['UserRead'] = getContext('user');
+	let movie: PublicMovie = $derived(page.data.movie);
+	let movieFiles: PublicMovieFile[] = $derived(page.data.movieFiles);
+	let user: () => UserRead = getContext('user');
 </script>
 
 <svelte:head>

--- a/web/src/routes/dashboard/movies/add-movie/+page.svelte
+++ b/web/src/routes/dashboard/movies/add-movie/+page.svelte
@@ -12,12 +12,12 @@
 	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { MetaDataProviderSearchResult } from '$lib/api/api';
 	import { handleQueryNotificationToast } from '$lib/utils.ts';
 
 	let searchTerm: string = $state('');
 	let metadataProvider: 'tmdb' | 'tvdb' = $state('tmdb');
-	let results: components['schemas']['MetaDataProviderSearchResult'][] | null = $state(null);
+	let results: MetaDataProviderSearchResult[] | null = $state(null);
 	let isSearching: boolean = $state(false);
 
 	onMount(() => {
@@ -39,7 +39,7 @@
 						})
 					: await client.GET('/api/v1/movies/recommended');
 			if (data && data.length > 0) {
-				results = data as components['schemas']['MetaDataProviderSearchResult'][];
+				results = data as MetaDataProviderSearchResult[];
 			} else {
 				results = null;
 			}

--- a/web/src/routes/dashboard/notifications/+page.svelte
+++ b/web/src/routes/dashboard/notifications/+page.svelte
@@ -6,11 +6,11 @@
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
 
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { Notification } from '$lib/api/api';
 	import { resolve } from '$app/paths';
 
-	let unreadNotifications: components['schemas']['Notification'][] = [];
-	let readNotifications: components['schemas']['Notification'][] = [];
+	let unreadNotifications: Notification[] = [];
+	let readNotifications: Notification[] = [];
 	let loading = true;
 	let showRead = false;
 	let markingAllAsRead = false;

--- a/web/src/routes/dashboard/settings/+page.svelte
+++ b/web/src/routes/dashboard/settings/+page.svelte
@@ -8,13 +8,11 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
 	import { resolve } from '$app/paths';
-	import type { components } from '$lib/api/api';
+	import type { UserRead } from '$lib/api/api';
 
-	let currentUser: () => components['schemas']['UserRead'] = getContext('user');
-	let users: components['schemas']['UserRead'][] = $derived(
-		page.data.users.filter(
-			(user: components['schemas']['UserRead']) => user.id !== currentUser().id
-		)
+	let currentUser: () => UserRead = getContext('user');
+	let users: UserRead[] = $derived(
+		page.data.users.filter((user: UserRead) => user.id !== currentUser().id)
 	);
 </script>
 

--- a/web/src/routes/dashboard/tv/+page.svelte
+++ b/web/src/routes/dashboard/tv/+page.svelte
@@ -8,14 +8,13 @@
 	import { resolve } from '$app/paths';
 	import ImportCandidatesDialog from '$lib/components/import-media/import-candidates-dialog.svelte';
 	import DetectedMediaCard from '$lib/components/import-media/detected-media-card.svelte';
-	import type { components } from '$lib/api/api';
+	import type { MediaImportSuggestion } from '$lib/api/api';
 	import { getContext } from 'svelte';
 	import type { PageProps } from './$types';
 	import LoadingBar from '$lib/components/loading-bar.svelte';
 
 	let { data }: PageProps = $props();
-	let importableShows: () => components['schemas']['MediaImportSuggestion'][] =
-		getContext('importableShows');
+	let importableShows: () => MediaImportSuggestion[] = getContext('importableShows');
 </script>
 
 <svelte:head>

--- a/web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/tv/[showId=uuid]/+page.svelte
@@ -7,7 +7,7 @@
 	import { Ellipsis } from 'lucide-svelte';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { getContext } from 'svelte';
-	import type { components } from '$lib/api/api';
+	import type { PublicShow, RichShowTorrent, UserRead } from '$lib/api/api';
 	import { getFullyQualifiedMediaName } from '$lib/utils';
 	import DownloadSelectedSeasonsDialog from '$lib/components/download-dialogs/download-selected-seasons-dialog.svelte';
 	import DownloadSelectedEpisodesDialog from '$lib/components/download-dialogs/download-selected-episodes-dialog.svelte';
@@ -27,9 +27,9 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { SvelteSet } from 'svelte/reactivity';
 
-	let show: components['schemas']['PublicShow'] = $derived(page.data.showData);
-	let torrents: components['schemas']['RichShowTorrent'] = $derived(page.data.torrentsData);
-	let user: () => components['schemas']['UserRead'] = getContext('user');
+	let show: PublicShow = $derived(page.data.showData);
+	let torrents: RichShowTorrent = $derived(page.data.torrentsData);
+	let user: () => UserRead = getContext('user');
 
 	let expandedSeasons = $state<Set<string>>(new Set());
 

--- a/web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelte
+++ b/web/src/routes/dashboard/tv/[showId=uuid]/[SeasonId=uuid]/+page.svelte
@@ -4,16 +4,16 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
-	import type { components } from '$lib/api/api';
+	import type { PublicEpisodeFile, Season, Show } from '$lib/api/api';
 	import CheckmarkX from '$lib/components/checkmark-x.svelte';
 	import { getFullyQualifiedMediaName, getTorrentQualityString } from '$lib/utils';
 	import MediaPicture from '$lib/components/media-picture.svelte';
 	import { resolve } from '$app/paths';
 	import * as Card from '$lib/components/ui/card/index.js';
 
-	let episodeFiles: components['schemas']['PublicEpisodeFile'][] = $derived(page.data.files);
-	let season: components['schemas']['Season'] = $derived(page.data.season);
-	let show: components['schemas']['Show'] = $derived(page.data.showData);
+	let episodeFiles: PublicEpisodeFile[] = $derived(page.data.files);
+	let season: Season = $derived(page.data.season);
+	let show: Show = $derived(page.data.showData);
 
 	let episodeById = $derived(
 		Object.fromEntries(

--- a/web/src/routes/dashboard/tv/add-show/+page.svelte
+++ b/web/src/routes/dashboard/tv/add-show/+page.svelte
@@ -12,12 +12,12 @@
 	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import client from '$lib/api';
-	import type { components } from '$lib/api/api';
+	import type { MetaDataProviderSearchResult } from '$lib/api/api';
 	import { handleQueryNotificationToast } from '$lib/utils.ts';
 
 	let searchTerm: string = $state('');
 	let metadataProvider: 'tmdb' | 'tvdb' = $state('tmdb');
-	let data: components['schemas']['MetaDataProviderSearchResult'][] | null = $state(null);
+	let data: MetaDataProviderSearchResult[] | null = $state(null);
 	let isSearching: boolean = $state(false);
 
 	onMount(() => {
@@ -40,7 +40,7 @@
 					: await client.GET('/api/v1/tv/recommended');
 			if (results.data && results.data.length > 0) {
 				handleQueryNotificationToast(results.data.length, query);
-				data = results.data as components['schemas']['MetaDataProviderSearchResult'][];
+				data = results.data as MetaDataProviderSearchResult[];
 			} else {
 				handleQueryNotificationToast(0, query);
 				data = null;

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import LoginCard from '$lib/components/auth/login-card.svelte';
 	import { page } from '$app/state';
-	import type { components } from '$lib/api/api';
-	let loginMetaData: components['schemas']['AuthMetadata'] = $derived(page.data.loginData);
+	import type { AuthMetadata } from '$lib/api/api';
+	let loginMetaData: AuthMetadata = $derived(page.data.loginData);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This PR adjusts the configuration to the `openapi-typescript` generation to export the schema types directly and allow importing them directly in the frontend code:
<img width="645" height="73" alt="image" src="https://github.com/user-attachments/assets/75ddb995-ac16-4154-842d-fd85d4bdea46" />

Alternatively without the `--root-types-no-schema-prefix` option, the schemas would all be prefixed with "Schema" like `SchemaMetaDataProviderSearchResult` which could be safer, if there are type collisions.

LMK what's preferred.

---
Checklist:
- [x] run `npm run openapi` to re-generate the `api.d.ts`
- [x] run `npm run lint`
- [x] run `npm run format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and standardised TypeScript typings across the web app by switching to concise public type aliases for API schemas (e.g. Movie, Show, Episode, User, Notification, etc.), improving code clarity and consistency across components and pages; purely type-level changes with no runtime behaviour impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->