### PR TITLE
feat: add NZBGet as alternative usenet download client

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -113,6 +113,15 @@ port = 8080
 api_key = ""
 base_path = "/api"
 
+# NZBGet settings
+[torrents.nzbget]
+enabled = false
+host = "localhost"
+port = 6789
+username = "nzbget"
+password = "tegbzn6789"
+use_https = false
+
 [indexers]
 # Prowlarr settings
 [indexers.prowlarr]

--- a/config.example.toml
+++ b/config.example.toml
@@ -113,6 +113,15 @@ port = 8080
 api_key = ""
 base_path = "/api"
 
+# NZBGet settings
+[torrents.nzbget]
+enabled = false
+host = "localhost"
+port = 6789
+username = "nzbget"
+password = "tegbzn6789"
+use_https = false
+
 [indexers]
 # Prowlarr settings
 [indexers.prowlarr]

--- a/docs/configuration/download-clients.md
+++ b/docs/configuration/download-clients.md
@@ -1,6 +1,6 @@
 # Download Clients
 
-Download client settings are configured in the `[torrents]` section of your `config.toml` file. MediaManager supports both qBittorrent and SABnzbd as download clients.
+Download client settings are configured in the `[torrents]` section of your `config.toml` file. MediaManager supports qBittorrent, Transmission, SABnzbd, and NZBGet as download clients.
 
 ## qBittorrent Settings (`[torrents.qbittorrent]`)
 
@@ -54,6 +54,23 @@ SABnzbd is a Usenet newsreader that MediaManager can integrate with for download
 * `base_path`\
   API base path for SABnzbd. It usually ends with `/api`, the default is `/api`.
 
+## NZBGet Settings (`[torrents.nzbget]`)
+
+NZBGet is a Usenet newsreader that MediaManager can integrate with for downloading NZB files. It is an alternative to SABnzbd.
+
+* `enabled`\
+  Set to `true` to enable NZBGet integration. Default is `false`.
+* `host`\
+  Hostname or IP of the NZBGet server (without protocol).
+* `port`\
+  Port of the NZBGet web interface. Default is `6789`.
+* `username`\
+  Username for NZBGet authentication. Default is `nzbget`.
+* `password`\
+  Password for NZBGet authentication. Default is `tegbzn6789`.
+* `use_https`\
+  Set to `true` if your NZBGet instance uses HTTPS. Default is `false`.
+
 ## Example Configuration
 
 Here's a complete example of the download clients section in your `config.toml`:
@@ -84,6 +101,15 @@ Here's a complete example of the download clients section in your `config.toml`:
     host = "http://sabnzbd"
     port = 8080
     api_key = "your_sabnzbd_api_key"
+
+    # NZBGet configuration
+    [torrents.nzbget]
+    enabled = false
+    host = "nzbget"
+    port = 6789
+    username = "nzbget"
+    password = "your_secure_password"
+    use_https = false
 ```
 
 ## Docker Compose Integration
@@ -113,6 +139,15 @@ services:
     image: lscr.io/linuxserver/sabnzbd:latest
     ports:
       - "8081:8080"
+    volumes:
+      - ./data/usenet:/downloads
+    # ... other configuration ...
+
+  # NZBGet service
+  nzbget:
+    image: lscr.io/linuxserver/nzbget:latest
+    ports:
+      - "6789:6789"
     volumes:
       - ./data/usenet:/downloads
     # ... other configuration ...

--- a/media_manager/torrent/config.py
+++ b/media_manager/torrent/config.py
@@ -30,7 +30,17 @@ class SabnzbdConfig(BaseSettings):
     base_path: str = "/api"
 
 
+class NzbgetConfig(BaseSettings):
+    host: str = "localhost"
+    port: int = 6789
+    username: str = "nzbget"
+    password: str = "tegbzn6789"  # noqa: S105
+    use_https: bool = False
+    enabled: bool = False
+
+
 class TorrentConfig(BaseSettings):
     qbittorrent: QbittorrentConfig = QbittorrentConfig()
     transmission: TransmissionConfig = TransmissionConfig()
     sabnzbd: SabnzbdConfig = SabnzbdConfig()
+    nzbget: NzbgetConfig = NzbgetConfig()

--- a/media_manager/torrent/download_clients/nzbget.py
+++ b/media_manager/torrent/download_clients/nzbget.py
@@ -1,0 +1,199 @@
+import logging
+
+import requests
+
+from media_manager.config import MediaManagerConfig
+from media_manager.indexer.schemas import IndexerQueryResult
+from media_manager.torrent.download_clients.abstract_download_client import (
+    AbstractDownloadClient,
+)
+from media_manager.torrent.schemas import Torrent, TorrentStatus
+
+log = logging.getLogger(__name__)
+
+
+class NzbgetDownloadClient(AbstractDownloadClient):
+    name = "nzbget"
+
+    DOWNLOADING_STATE = (
+        "QUEUED",
+        "PAUSED",
+        "DOWNLOADING",
+        "FETCHING",
+        "PP_QUEUED",
+        "LOADING_PARS",
+        "VERIFYING_SOURCES",
+        "REPAIRING",
+        "VERIFYING_REPAIRED",
+        "RENAMING",
+        "UNPACKING",
+        "MOVING",
+        "EXECUTING_SCRIPT",
+    )
+    FINISHED_STATE = ("SUCCESS",)
+    ERROR_STATE = ("FAILURE",)
+
+    def __init__(self) -> None:
+        self.config = MediaManagerConfig().torrents.nzbget
+        scheme = "https" if self.config.use_https else "http"
+        self._base_url = f"{scheme}://{self.config.host}:{self.config.port}"
+        self._auth = (self.config.username, self.config.password)
+        try:
+            self._call("version")
+        except Exception:
+            log.exception("Failed to connect to NZBGet")
+            raise
+
+    def _call(self, method: str, params: list | None = None) -> object:
+        """
+        Make a JSON-RPC call to NZBGet.
+
+        :param method: The API method name.
+        :param params: Optional list of positional parameters.
+        :return: The 'result' field of the JSON-RPC response.
+        """
+        url = f"{self._base_url}/jsonrpc"
+        payload: dict = {"method": method, "id": 1}
+        if params is not None:
+            payload["params"] = params
+
+        response = requests.post(url, json=payload, auth=self._auth, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data and data["error"] is not None:
+            msg = f"NZBGet API error: {data['error']}"
+            raise RuntimeError(msg)
+
+        return data.get("result")
+
+    def download_torrent(self, indexer_result: IndexerQueryResult) -> Torrent:
+        """
+        Add a NZB to NZBGet and return the torrent object.
+
+        :param indexer_result: The indexer query result of the NZB file to download.
+        :return: The torrent object with calculated hash and initial status.
+        """
+        try:
+            # NZBGet append params:
+            # NZBFilename, Content (base64 or empty), Category, Priority,
+            # AddToTop, AddPaused, DupeKey, DupeScore, DupeMode, PPParameters
+            nzb_id = self._call(
+                "append",
+                [
+                    indexer_result.title + ".nzb",  # NZBFilename
+                    str(indexer_result.download_url),  # Content (URL when no base64)
+                    "",  # Category
+                    0,  # Priority (normal)
+                    False,  # AddToTop
+                    False,  # AddPaused
+                    "",  # DupeKey
+                    0,  # DupeScore
+                    "SCORE",  # DupeMode
+                    [],  # PPParameters
+                ],
+            )
+
+            if not nzb_id or nzb_id <= 0:
+                msg = f"Failed to add NZB to NZBGet: returned id {nzb_id}"
+                raise RuntimeError(msg)  # noqa: TRY301
+
+            torrent = Torrent(
+                status=TorrentStatus.unknown,
+                title=indexer_result.title,
+                quality=indexer_result.quality,
+                imported=False,
+                hash=str(nzb_id),
+                usenet=True,
+            )
+
+            torrent.status = self.get_torrent_status(torrent)
+        except Exception:
+            log.exception(f"Failed to download NZB {indexer_result.title}")
+            raise
+
+        return torrent
+
+    def remove_torrent(self, torrent: Torrent, delete_data: bool = False) -> None:
+        """
+        Remove a download from NZBGet.
+
+        :param torrent: The torrent to remove.
+        :param delete_data: Whether to delete the downloaded files.
+        """
+        try:
+            nzb_id = int(torrent.hash)
+            # Try removing from queue first
+            result = self._call("editqueue", ["GroupDelete", "", [nzb_id]])
+            if not result:
+                # If not in queue, try removing from history
+                self._call("editqueue", ["HistoryDelete", "", [nzb_id]])
+        except Exception:
+            log.exception(f"Failed to remove torrent {torrent.title}")
+            raise
+
+    def pause_torrent(self, torrent: Torrent) -> None:
+        """
+        Pause a download in NZBGet.
+
+        :param torrent: The torrent to pause.
+        """
+        try:
+            nzb_id = int(torrent.hash)
+            self._call("editqueue", ["GroupPause", "", [nzb_id]])
+        except Exception:
+            log.exception(f"Failed to pause torrent {torrent.title}")
+            raise
+
+    def resume_torrent(self, torrent: Torrent) -> None:
+        """
+        Resume a paused download in NZBGet.
+
+        :param torrent: The torrent to resume.
+        """
+        try:
+            nzb_id = int(torrent.hash)
+            self._call("editqueue", ["GroupResume", "", [nzb_id]])
+        except Exception:
+            log.exception(f"Failed to resume torrent {torrent.title}")
+            raise
+
+    def get_torrent_status(self, torrent: Torrent) -> TorrentStatus:
+        """
+        Get the status of a specific download from NZBGet.
+
+        :param torrent: The torrent to get the status of.
+        :return: The status of the torrent.
+        """
+        nzb_id = int(torrent.hash)
+
+        # Check active queue first
+        groups = self._call("listgroups")
+        if isinstance(groups, list):
+            for group in groups:
+                if group.get("NZBID") == nzb_id:
+                    return self._map_status(group.get("Status", "UNKNOWN"))
+
+        # Check history for completed/failed items
+        history = self._call("history")
+        if isinstance(history, list):
+            for item in history:
+                if item.get("NZBID") == nzb_id:
+                    return self._map_status(item.get("Status", "UNKNOWN"))
+
+        return TorrentStatus.unknown
+
+    def _map_status(self, nzbget_status: str) -> TorrentStatus:
+        """
+        Map NZBGet status to TorrentStatus.
+
+        :param nzbget_status: The status from NZBGet.
+        :return: The corresponding TorrentStatus.
+        """
+        if nzbget_status in self.DOWNLOADING_STATE:
+            return TorrentStatus.downloading
+        if nzbget_status in self.FINISHED_STATE:
+            return TorrentStatus.finished
+        if nzbget_status in self.ERROR_STATE:
+            return TorrentStatus.error
+        return TorrentStatus.unknown

--- a/media_manager/torrent/download_clients/nzbget.py
+++ b/media_manager/torrent/download_clients/nzbget.py
@@ -127,7 +127,8 @@ class NzbgetDownloadClient(AbstractDownloadClient):
             result = self._call("editqueue", ["GroupDelete", "", [nzb_id]])
             if not result:
                 # If not in queue, try removing from history
-                self._call("editqueue", ["HistoryDelete", "", [nzb_id]])
+                history_cmd = "HistoryFinalDelete" if delete_data else "HistoryDelete"
+                self._call("editqueue", [history_cmd, "", [nzb_id]])
         except Exception:
             log.exception(f"Failed to remove torrent {torrent.title}")
             raise

--- a/media_manager/torrent/manager.py
+++ b/media_manager/torrent/manager.py
@@ -7,6 +7,7 @@ from media_manager.torrent.download_clients.abstract_download_client import (
     AbstractDownloadClient,
 )
 from media_manager.torrent.download_clients.qbittorrent import QbittorrentDownloadClient
+from media_manager.torrent.download_clients.nzbget import NzbgetDownloadClient
 from media_manager.torrent.download_clients.sabnzbd import SabnzbdDownloadClient
 from media_manager.torrent.download_clients.transmission import (
     TransmissionDownloadClient,
@@ -53,12 +54,18 @@ class DownloadManager:
             except Exception:
                 log.exception("Failed to initialize Transmission client")
 
-        # Initialize SABnzbd client for usenet
+        # Initialize usenet client (prioritize SABnzbd, fallback to NZBGet)
         if self.config.sabnzbd.enabled:
             try:
                 self._usenet_client = SabnzbdDownloadClient()
             except Exception:
                 log.exception("Failed to initialize SABnzbd client")
+
+        if self._usenet_client is None and self.config.nzbget.enabled:
+            try:
+                self._usenet_client = NzbgetDownloadClient()
+            except Exception:
+                log.exception("Failed to initialize NZBGet client")
 
         active_clients = []
         if self._torrent_client:

--- a/media_manager/torrent/manager.py
+++ b/media_manager/torrent/manager.py
@@ -6,8 +6,8 @@ from media_manager.indexer.schemas import IndexerQueryResult
 from media_manager.torrent.download_clients.abstract_download_client import (
     AbstractDownloadClient,
 )
-from media_manager.torrent.download_clients.qbittorrent import QbittorrentDownloadClient
 from media_manager.torrent.download_clients.nzbget import NzbgetDownloadClient
+from media_manager.torrent.download_clients.qbittorrent import QbittorrentDownloadClient
 from media_manager.torrent.download_clients.sabnzbd import SabnzbdDownloadClient
 from media_manager.torrent.download_clients.transmission import (
     TransmissionDownloadClient,

--- a/ruff.toml
+++ b/ruff.toml
@@ -40,5 +40,8 @@ ignore = [
     "TD002", "TD003",
 ]
 
+[lint.per-file-ignores]
+"tests/**/*.py" = ["S101", "S105", "ANN"]
+
 [lint.flake8-bugbear]
 extend-immutable-calls = ["fastapi.Depends", "fastapi.Path", "taskiq.TaskiqDepends"]

--- a/tests/test_nzbget.py
+++ b/tests/test_nzbget.py
@@ -1,0 +1,338 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from media_manager.torrent.download_clients.nzbget import NzbgetDownloadClient
+from media_manager.torrent.schemas import Quality, Torrent, TorrentStatus
+
+
+@pytest.fixture
+def mock_config():
+    config = MagicMock()
+    config.host = "localhost"
+    config.port = 6789
+    config.username = "nzbget"
+    config.password = "tegbzn6789"
+    config.use_https = False
+    return config
+
+
+@pytest.fixture
+def nzbget_client(mock_config):
+    with (
+        patch(
+            "media_manager.torrent.download_clients.nzbget.MediaManagerConfig"
+        ) as mock_mm_config,
+        patch("media_manager.torrent.download_clients.nzbget.requests") as mock_requests,
+    ):
+        mock_mm_config.return_value.torrents.nzbget = mock_config
+        # Mock the version call during __init__
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": "21.1", "id": 1}
+        mock_response.raise_for_status = MagicMock()
+        mock_requests.post.return_value = mock_response
+
+        client = NzbgetDownloadClient()
+        # Replace requests reference so subsequent calls can be mocked cleanly
+        client._requests = mock_requests
+        return client
+
+
+class TestNzbgetStatusMapping:
+    def test_downloading_states(self, nzbget_client):
+        downloading_states = [
+            "QUEUED",
+            "PAUSED",
+            "DOWNLOADING",
+            "FETCHING",
+            "PP_QUEUED",
+            "LOADING_PARS",
+            "VERIFYING_SOURCES",
+            "REPAIRING",
+            "VERIFYING_REPAIRED",
+            "RENAMING",
+            "UNPACKING",
+            "MOVING",
+            "EXECUTING_SCRIPT",
+        ]
+        for state in downloading_states:
+            assert nzbget_client._map_status(state) == TorrentStatus.downloading
+
+    def test_finished_state(self, nzbget_client):
+        assert nzbget_client._map_status("SUCCESS") == TorrentStatus.finished
+
+    def test_error_state(self, nzbget_client):
+        assert nzbget_client._map_status("FAILURE") == TorrentStatus.error
+
+    def test_unknown_state(self, nzbget_client):
+        assert nzbget_client._map_status("SOMETHING_ELSE") == TorrentStatus.unknown
+
+
+class TestNzbgetDownloadClient:
+    def test_init_builds_correct_url(self, mock_config):
+        with (
+            patch(
+                "media_manager.torrent.download_clients.nzbget.MediaManagerConfig"
+            ) as mock_mm_config,
+            patch(
+                "media_manager.torrent.download_clients.nzbget.requests"
+            ) as mock_requests,
+        ):
+            mock_mm_config.return_value.torrents.nzbget = mock_config
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"result": "21.1", "id": 1}
+            mock_response.raise_for_status = MagicMock()
+            mock_requests.post.return_value = mock_response
+
+            client = NzbgetDownloadClient()
+
+            assert client._base_url == "http://localhost:6789"
+            assert client._auth == ("nzbget", "tegbzn6789")
+
+    def test_init_https(self, mock_config):
+        mock_config.use_https = True
+        with (
+            patch(
+                "media_manager.torrent.download_clients.nzbget.MediaManagerConfig"
+            ) as mock_mm_config,
+            patch(
+                "media_manager.torrent.download_clients.nzbget.requests"
+            ) as mock_requests,
+        ):
+            mock_mm_config.return_value.torrents.nzbget = mock_config
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"result": "21.1", "id": 1}
+            mock_response.raise_for_status = MagicMock()
+            mock_requests.post.return_value = mock_response
+
+            client = NzbgetDownloadClient()
+
+            assert client._base_url == "https://localhost:6789"
+
+    def test_init_connection_failure(self, mock_config):
+        with (
+            patch(
+                "media_manager.torrent.download_clients.nzbget.MediaManagerConfig"
+            ) as mock_mm_config,
+            patch(
+                "media_manager.torrent.download_clients.nzbget.requests"
+            ) as mock_requests,
+        ):
+            mock_mm_config.return_value.torrents.nzbget = mock_config
+            mock_requests.post.side_effect = ConnectionError("Connection refused")
+
+            with pytest.raises(ConnectionError):
+                NzbgetDownloadClient()
+
+    def test_call_api_error(self, nzbget_client):
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "error": {"name": "Error", "message": "Bad request"},
+                "id": 1,
+            }
+            mock_response.raise_for_status = MagicMock()
+            mock_requests.post.return_value = mock_response
+
+            with pytest.raises(RuntimeError, match="NZBGet API error"):
+                nzbget_client._call("badmethod")
+
+    def test_download_torrent(self, nzbget_client):
+        indexer_result = MagicMock()
+        indexer_result.title = "Test.Show.S01E01.720p"
+        indexer_result.download_url = "http://example.com/test.nzb"
+        indexer_result.quality = Quality.hd
+
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            # First call: append returns NZB ID
+            # Second call: listgroups for status check
+            append_response = MagicMock()
+            append_response.json.return_value = {"result": 12345, "id": 1}
+            append_response.raise_for_status = MagicMock()
+
+            status_response = MagicMock()
+            status_response.json.return_value = {
+                "result": [{"NZBID": 12345, "Status": "QUEUED"}],
+                "id": 1,
+            }
+            status_response.raise_for_status = MagicMock()
+
+            mock_requests.post.side_effect = [append_response, status_response]
+
+            torrent = nzbget_client.download_torrent(indexer_result)
+
+            assert torrent.hash == "12345"
+            assert torrent.title == "Test.Show.S01E01.720p"
+            assert torrent.usenet is True
+            assert torrent.status == TorrentStatus.downloading
+
+    def test_download_torrent_failure(self, nzbget_client):
+        indexer_result = MagicMock()
+        indexer_result.title = "Test.Show.S01E01.720p"
+        indexer_result.download_url = "http://example.com/test.nzb"
+
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            fail_response = MagicMock()
+            fail_response.json.return_value = {"result": -1, "id": 1}
+            fail_response.raise_for_status = MagicMock()
+            mock_requests.post.return_value = fail_response
+
+            with pytest.raises(RuntimeError, match="Failed to add NZB"):
+                nzbget_client.download_torrent(indexer_result)
+
+    def test_remove_torrent(self, nzbget_client):
+        torrent = Torrent(
+            status=TorrentStatus.downloading,
+            title="Test",
+            quality=Quality.hd,
+            imported=False,
+            hash="12345",
+            usenet=True,
+        )
+
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"result": True, "id": 1}
+            mock_response.raise_for_status = MagicMock()
+            mock_requests.post.return_value = mock_response
+
+            nzbget_client.remove_torrent(torrent)
+
+            call_args = mock_requests.post.call_args
+            payload = call_args[1]["json"] if "json" in call_args[1] else call_args[0][1]
+            assert payload["method"] == "editqueue"
+
+    def test_pause_torrent(self, nzbget_client):
+        torrent = Torrent(
+            status=TorrentStatus.downloading,
+            title="Test",
+            quality=Quality.hd,
+            imported=False,
+            hash="12345",
+            usenet=True,
+        )
+
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"result": True, "id": 1}
+            mock_response.raise_for_status = MagicMock()
+            mock_requests.post.return_value = mock_response
+
+            nzbget_client.pause_torrent(torrent)
+
+            call_args = mock_requests.post.call_args
+            payload = call_args[1]["json"] if "json" in call_args[1] else call_args[0][1]
+            assert payload["method"] == "editqueue"
+            assert payload["params"][0] == "GroupPause"
+
+    def test_resume_torrent(self, nzbget_client):
+        torrent = Torrent(
+            status=TorrentStatus.downloading,
+            title="Test",
+            quality=Quality.hd,
+            imported=False,
+            hash="12345",
+            usenet=True,
+        )
+
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"result": True, "id": 1}
+            mock_response.raise_for_status = MagicMock()
+            mock_requests.post.return_value = mock_response
+
+            nzbget_client.resume_torrent(torrent)
+
+            call_args = mock_requests.post.call_args
+            payload = call_args[1]["json"] if "json" in call_args[1] else call_args[0][1]
+            assert payload["method"] == "editqueue"
+            assert payload["params"][0] == "GroupResume"
+
+    def test_get_torrent_status_from_queue(self, nzbget_client):
+        torrent = Torrent(
+            status=TorrentStatus.unknown,
+            title="Test",
+            quality=Quality.hd,
+            imported=False,
+            hash="12345",
+            usenet=True,
+        )
+
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "result": [{"NZBID": 12345, "Status": "DOWNLOADING"}],
+                "id": 1,
+            }
+            mock_response.raise_for_status = MagicMock()
+            mock_requests.post.return_value = mock_response
+
+            status = nzbget_client.get_torrent_status(torrent)
+            assert status == TorrentStatus.downloading
+
+    def test_get_torrent_status_from_history(self, nzbget_client):
+        torrent = Torrent(
+            status=TorrentStatus.unknown,
+            title="Test",
+            quality=Quality.hd,
+            imported=False,
+            hash="12345",
+            usenet=True,
+        )
+
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            # First call: listgroups returns empty
+            queue_response = MagicMock()
+            queue_response.json.return_value = {"result": [], "id": 1}
+            queue_response.raise_for_status = MagicMock()
+
+            # Second call: history returns completed item
+            history_response = MagicMock()
+            history_response.json.return_value = {
+                "result": [{"NZBID": 12345, "Status": "SUCCESS"}],
+                "id": 1,
+            }
+            history_response.raise_for_status = MagicMock()
+
+            mock_requests.post.side_effect = [queue_response, history_response]
+
+            status = nzbget_client.get_torrent_status(torrent)
+            assert status == TorrentStatus.finished
+
+    def test_get_torrent_status_not_found(self, nzbget_client):
+        torrent = Torrent(
+            status=TorrentStatus.unknown,
+            title="Test",
+            quality=Quality.hd,
+            imported=False,
+            hash="99999",
+            usenet=True,
+        )
+
+        with patch(
+            "media_manager.torrent.download_clients.nzbget.requests"
+        ) as mock_requests:
+            empty_response = MagicMock()
+            empty_response.json.return_value = {"result": [], "id": 1}
+            empty_response.raise_for_status = MagicMock()
+
+            mock_requests.post.return_value = empty_response
+
+            status = nzbget_client.get_torrent_status(torrent)
+            assert status == TorrentStatus.unknown


### PR DESCRIPTION
🚧 **Draft** — awaiting internal review from dev-mill before marking ready-for-review.

Closes https://github.com/maxdorninger/MediaManager/issues/149

## Summary

Adds NZBGet as an alternative Usenet download client alongside the existing SABnzbd support. NZBGet communicates via its JSON-RPC API using the `requests` library (already a dependency), so no new packages are required.

**Changes:**
- New `NzbgetDownloadClient` implementing `AbstractDownloadClient` with full support for download, remove, pause, resume, and status tracking
- `NzbgetConfig` in the config layer with host, port, username/password auth, and HTTPS toggle
- `DownloadManager` updated to initialize NZBGet as a fallback when SABnzbd is not enabled
- Configuration examples in `config.example.toml` and `config.dev.toml`
- Documentation updated with NZBGet settings reference and Docker Compose example
- Per-file lint ignores added for test directory

## Testing

- 16 unit tests covering:
  - Status mapping (all NZBGet states → TorrentStatus)
  - Client initialization (HTTP, HTTPS, connection failure)
  - API error handling
  - Download, remove, pause, resume operations
  - Status retrieval from both active queue and history
  - Not-found status handling
- All tests pass: `pytest tests/test_nzbget.py -v` (16/16)
- Ruff lint passes on all changed files

Opened by the dev-mill assembly-line fix pipeline (https://devmill.aletheia.dev/). This is an autonomous contribution — feedback welcome.