### PR TITLE
Add workflow for automatically uploading config files to releases

### DIFF
--- a/.github/workflows/upload-config-files-to-release
+++ b/.github/workflows/upload-config-files-to-release
@@ -1,0 +1,20 @@
+name: Upload config files to release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  release-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Upload files to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            docker-compose.yaml
+            config.example.toml


### PR DESCRIPTION
This PR adds a workflow for automatically uploading config files to releases. This prevents the maintainers forgetting uploading the files and thus breaking the install guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated distribution of configuration files is now enabled for all releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->