### PR TITLE
test: add backend simple tests and enable ty check

### DIFF
--- a/.github/workflows/backend-test-lint.yml
+++ b/.github/workflows/backend-test-lint.yml
@@ -1,31 +1,23 @@
-name: Backend Test/Lint
+name: Backend Test and Lint
 
 on:
   push:
     branches:
       - master
-    paths:
-      - 'media_manager/**'
-      - 'tests/**'
-      - 'conftest.py'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'ruff.toml'
-      - 'config.example.toml'
-      - '.github/workflows/test-backend.yml'
 
   pull_request:
-    paths:
-      - 'media_manager/**'
-      - 'tests/**'
-      - 'conftest.py'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'ruff.toml'
-      - 'config.example.toml'
-      - '.github/workflows/test-backend.yml'
 
   workflow_dispatch:
+
+  # Allow this workflow to be invoked from build-push-backend.yml so the
+  # build/push job can depend on lint + type-check + tests in one place.
+  workflow_call:
+
+
+concurrency:
+  group: backend-test-lint-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   ruff:
@@ -59,7 +51,7 @@ jobs:
       - run: uv run ty check media_manager/ conftest.py tests/
 
   pytest:
-    name: pytest (fast lane)
+    name: pytest (unit & integrations)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   # Reuse workflow instead of duplicating ruff/pytest calls here
-  backend-checks:
+  backend-test-lint:
     uses: ./.github/workflows/backend-test-lint.yml
 
   lint-frontend:
@@ -56,7 +56,7 @@ jobs:
         working-directory: ./web
 
   build-and-push:
-    needs: [lint-frontend, backend-checks]
+    needs: [lint-frontend, backend-test-lint]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -33,14 +33,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint-backend:
-    name: Lint Python Code
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
-        with:
-          src: "./media_manager"
+  # Reuse workflow instead of duplicating ruff/pytest calls here
+  backend-checks:
+    uses: ./.github/workflows/backend-test-lint.yml
 
   lint-frontend:
     name: Lint Frontend
@@ -61,7 +56,7 @@ jobs:
         working-directory: ./web
 
   build-and-push:
-    needs: [lint-frontend, lint-backend]
+    needs: [lint-frontend, backend-checks]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -43,21 +43,20 @@ jobs:
       - run: uv run ruff check .
       - run: uv run ruff format --check .
 
-  # TODO: enable once the existing ty diagnostics are addressed
-  # (72 pre-existing errors as of 2026-05-16).
-  # ty:
-  #   name: ty (type check)
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: astral-sh/setup-uv@v4
-  #       with:
-  #         enable-cache: true
-  #         cache-dependency-glob: uv.lock
-  #     - run: uv python install 3.13
-  #     - run: uv sync --group dev
-  #     - run: uv run ty check
+  ty:
+    name: ty (type check)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv python install 3.13
+      - run: uv sync --group dev
+      # metadata_relay is a separate project with its own pyproject.toml.
+      - run: uv run ty check media_manager/ conftest.py tests/
 
   pytest:
     name: pytest (fast lane)

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -1,0 +1,74 @@
+name: Backend Test/Lint
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'media_manager/**'
+      - 'tests/**'
+      - 'conftest.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'ruff.toml'
+      - 'config.example.toml'
+      - '.github/workflows/test-backend.yml'
+
+  pull_request:
+    paths:
+      - 'media_manager/**'
+      - 'tests/**'
+      - 'conftest.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'ruff.toml'
+      - 'config.example.toml'
+      - '.github/workflows/test-backend.yml'
+
+  workflow_dispatch:
+
+jobs:
+  ruff:
+    name: ruff (lint + format)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv python install 3.13
+      - run: uv sync --group dev
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+
+  # TODO: enable once the existing ty diagnostics are addressed
+  # (72 pre-existing errors as of 2026-05-16).
+  # ty:
+  #   name: ty (type check)
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 5
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: astral-sh/setup-uv@v4
+  #       with:
+  #         enable-cache: true
+  #         cache-dependency-glob: uv.lock
+  #     - run: uv python install 3.13
+  #     - run: uv sync --group dev
+  #     - run: uv run ty check
+
+  pytest:
+    name: pytest (fast lane)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv python install 3.13
+      - run: uv sync --group dev
+      - run: uv run pytest

--- a/conftest.py
+++ b/conftest.py
@@ -39,10 +39,11 @@ from media_manager.indexer.config import (  # noqa: E402
     IndexerFlagScoringRule,
     TitleScoringRule,
 )
+from tests.types import PatchScoringRules  # noqa: E402
 
 
 @pytest.fixture
-def patch_scoring_rules(monkeypatch: pytest.MonkeyPatch) -> "PatchScoringRules":
+def patch_scoring_rules(monkeypatch: pytest.MonkeyPatch) -> PatchScoringRules:
     """Inject scoring rules into the config for the indexer utils module.
 
     MediaManagerConfig() returns a freshly-loaded instance per call, so we

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,65 @@
+"""Top-level pytest configuration.
+
+The CONFIG_FILE env var must be set before media_manager.config is imported,
+because that module reads it at import time and constructs a settings
+instance whose TomlConfigSettingsSource fails if the path does not exist.
+We point it at the in-repo example config so unit tests can import freely.
+"""
+
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+
+os.environ.setdefault("CONFIG_FILE", str(REPO_ROOT / "config.example.toml"))
+# main.py mounts a StaticFiles route from FRONTEND_FILES_DIR at import time
+# unless this flag is set, which would fail in CI where no build exists.
+os.environ.setdefault("DISABLE_FRONTEND_MOUNT", "true")
+# logging.py defaults LOG_FILE to /app/config/media_manager.log, which the
+# RotatingFileHandler tries to open at app startup; redirect to a writable
+# temp path so the dict-config doesn't fail when the app is booted in tests.
+_TEST_DATA_ROOT = REPO_ROOT / ".pytest_cache" / "data"
+_TEST_DATA_ROOT.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault(
+    "LOG_FILE", str(REPO_ROOT / ".pytest_cache" / "media_manager.log")
+)
+# config.example.toml points the media directories at /data/* (container
+# paths). Override with writable temp paths so run_filesystem_checks
+# succeeds when the app is booted in tests. Uses pydantic-settings env
+# delimiter `__`.
+for _name in ("tv", "movie", "torrent", "image"):
+    os.environ.setdefault(
+        f"MEDIAMANAGER_MISC__{_name.upper()}_DIRECTORY",
+        str(_TEST_DATA_ROOT / _name),
+    )
+
+import pytest  # noqa: E402
+
+from media_manager.indexer.config import (  # noqa: E402
+    IndexerFlagScoringRule,
+    TitleScoringRule,
+)
+
+
+@pytest.fixture
+def patch_scoring_rules(monkeypatch: pytest.MonkeyPatch) -> "PatchScoringRules":
+    """Inject scoring rules into the config for the indexer utils module.
+
+    MediaManagerConfig() returns a freshly-loaded instance per call, so we
+    can't mutate one instance and expect the next call to see it. Instead,
+    replace the symbol that indexer.utils imported so every call inside the
+    function under test returns the same pre-built instance.
+    """
+    import media_manager.indexer.utils as indexer_utils
+    from media_manager.config import MediaManagerConfig
+
+    def _apply(
+        title: list[TitleScoringRule] | None = None,
+        flags: list[IndexerFlagScoringRule] | None = None,
+    ) -> None:
+        cfg = MediaManagerConfig()
+        cfg.indexers.title_scoring_rules = title or []
+        cfg.indexers.indexer_flag_scoring_rules = flags or []
+        monkeypatch.setattr(indexer_utils, "MediaManagerConfig", lambda: cfg)
+
+    return _apply

--- a/docs/contributing-to-mediamanager/developer-guide.md
+++ b/docs/contributing-to-mediamanager/developer-guide.md
@@ -197,19 +197,45 @@ uv run alembic upgrade head
 uv run fastapi run media_manager/main.py --reload --port 8000
 ```
 
-### Formatting & linting
+### Formatting, linting & type-checking
 
-* Format code:
-
-```bash
-ruff format .
-```
-
-* Lint code:
+* Format code with [ruff](https://github.com/astral-sh/ruff):
 
 ```bash
-ruff check .
+uv run ruff format .
 ```
+
+* Lint code with [ruff](https://github.com/astral-sh/ruff):
+
+```bash
+uv run ruff check .
+```
+
+* Type-check code with [ty](https://github.com/astral-sh/ty):
+
+```bash
+# metadata_relay is a separate project with its own pyproject.toml,
+# so it's excluded from the root check.
+uv run ty check media_manager/ conftest.py tests/
+```
+
+  The `# ty: ignore[<rule>]` comment is the supported suppression
+  (NOT `# type: ignore[...]` — that's mypy, silently dropped by ty).
+
+### Running tests
+
+Unit tests live next to source under `media_manager/<feature>/tests/`;
+integration and API tests live in `tests/`. 
+
+```bash
+uv run pytest
+```
+
+* `db` and `indexer` markers gate tests that need a real database or live indexer
+respectively — neither runs by default.
+
+
+---
 
 ## Setting up the frontend development environment (Local, Optional)
 

--- a/media_manager/auth/router.py
+++ b/media_manager/auth/router.py
@@ -34,7 +34,7 @@ def get_openid_router() -> APIRouter:
     if openid_client:
         return get_oauth_router(
             oauth_client=openid_client,
-            backend=openid_cookie_auth_backend,
+            backend=openid_cookie_auth_backend,  # ty: ignore[invalid-argument-type]
             get_user_manager=fastapi_users.get_user_manager,
             state_secret=SECRET,
             associate_by_email=True,
@@ -50,7 +50,7 @@ def get_openid_router() -> APIRouter:
             authorize_endpoint="https://example.com/authorize",
             access_token_endpoint="https://example.com/token",  # noqa: S106
         ),
-        backend=openid_cookie_auth_backend,
+        backend=openid_cookie_auth_backend,  # ty: ignore[invalid-argument-type]
         get_user_manager=fastapi_users.get_user_manager,
         state_secret=SECRET,
         associate_by_email=False,

--- a/media_manager/auth/users.py
+++ b/media_manager/auth/users.py
@@ -57,7 +57,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             log.info(f"User {user.id} has been granted superuser privileges.")
         if "email" in update_dict:
             updated_user = UserUpdate(is_verified=True)
-            await self.update(user=user, user_update=updated_user)
+            # `user` is typed as the upstream `models.UP` TypeVar; ty cannot
+            # see that it is concretely our `User` model here.
+            await self.update(user=user, user_update=updated_user)  # ty: ignore[invalid-argument-type]
 
     @override
     async def on_after_register(
@@ -136,7 +138,9 @@ async def create_default_admin_user() -> None:
             async with get_user_db_context(session) as user_db:
                 async with get_user_manager_context(user_db) as user_manager:
                     # Check if any users exist
-                    stmt = select(func.count(User.id))
+                    # User.id is a Mapped[UUID]; ty resolves it to plain
+                    # UUID and rejects it as a count() arg.
+                    stmt = select(func.count(User.id))  # ty: ignore[invalid-argument-type]
                     result = await session.execute(stmt)
                     user_count = result.scalar()
                     config = MediaManagerConfig()
@@ -221,8 +225,15 @@ openid_cookie_auth_backend = AuthenticationBackend(
     get_strategy=get_jwt_strategy,
 )
 
+# AuthenticationBackend is invariant in its generic params, so ty rejects
+# our concrete backends against the FastAPIUsers / get_auth_router / get_oauth_router
+# TypeVars. The runtime API accepts them. Suppression sites:
+#   - this file (FastAPIUsers ctor below)
+#   - media_manager/main.py (get_auth_router)
+#   - media_manager/auth/router.py (get_oauth_router)
 fastapi_users = FastAPIUsers[User, uuid.UUID](
-    get_user_manager, [bearer_auth_backend, cookie_auth_backend]
+    get_user_manager,
+    [bearer_auth_backend, cookie_auth_backend],  # ty: ignore[invalid-argument-type]
 )
 
 current_active_user = fastapi_users.current_user(active=True, verified=True)

--- a/media_manager/common/repository.py
+++ b/media_manager/common/repository.py
@@ -1,21 +1,22 @@
 import logging
-from typing import Any, TypeVar
+from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from pydantic import BaseModel
+from sqlalchemy import CursorResult, delete, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
+from media_manager.common.schemas import BaseMedia
+from media_manager.database import Base
 from media_manager.exceptions import ConflictError, NotFoundError
 
 log = logging.getLogger(__name__)
 
-T = TypeVar("T")
-S = TypeVar("S")
 EntityId = UUID | int | str
 
 
-class BaseRepository[T, S]:
+class BaseRepository[T: Base, S: BaseMedia]:
     """
     Base repository providing common CRUD operations for media models.
     """
@@ -138,11 +139,15 @@ class BaseRepository[T, S]:
 
         return self.schema.model_validate(db_obj)
 
-    def add_media_file_base(
-        self, file_schema: S, model_class: type[T], schema_class: type[S]
-    ) -> S:
+    def add_media_file_base[FT: Base, FS: BaseModel](
+        self, file_schema: FS, model_class: type[FT], schema_class: type[FS]
+    ) -> FS:
         """
         Generic method to add a media file record.
+
+        The file model / schema can differ from the repository's own T/S
+        (e.g. a MoviesRepository[Movie, MovieSchema] inserts MovieFile rows),
+        so this method carries its own type parameters.
         """
         db_model = model_class(**file_schema.model_dump())
         try:
@@ -172,4 +177,6 @@ class BaseRepository[T, S]:
             self.db.rollback()
             raise
         else:
-            return result.rowcount
+            # execute(delete(...)) returns a CursorResult, which exposes
+            # rowcount; the public Result interface does not.
+            return cast(CursorResult, result).rowcount

--- a/media_manager/common/schemas.py
+++ b/media_manager/common/schemas.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from media_manager.torrent.models import Quality
+from media_manager.torrent.schemas import TorrentId
 
 
 class BaseMedia(BaseModel):
@@ -24,7 +25,7 @@ class BaseMediaFile(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     quality: Quality
-    torrent_id: UUID | None = None
+    torrent_id: TorrentId | None = None
     file_path_suffix: str
 
 

--- a/media_manager/common/service.py
+++ b/media_manager/common/service.py
@@ -1,9 +1,11 @@
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any
 
 from media_manager.common.repository import BaseRepository
+from media_manager.common.schemas import BaseMedia
+from media_manager.database import Base
 from media_manager.exceptions import InvalidConfigError, NotFoundError
 from media_manager.indexer.service import IndexerService
 from media_manager.metadataProvider.abstract_metadata_provider import (
@@ -20,11 +22,8 @@ from media_manager.torrent.utils import (
 
 log = logging.getLogger(__name__)
 
-T = TypeVar("T")
-S = TypeVar("S")
 
-
-class BaseMediaService[T, S]:
+class BaseMediaService[T: Base, S: BaseMedia]:
     """
     Base service providing common logic for media modules.
     """
@@ -50,7 +49,7 @@ class BaseMediaService[T, S]:
         """
         Determines the root directory for a media item.
         """
-        if hasattr(media, "library") and media.library:
+        if media.library:
             for library in libraries:
                 if library.name == media.library:
                     return Path(library.path) / Path(
@@ -83,7 +82,7 @@ class BaseMediaService[T, S]:
                 message=msg,
             )
 
-    def get_import_candidates(
+    def _get_import_candidates_base(
         self,
         directory: Path,
         metadata_provider: AbstractMetadataProvider,
@@ -95,7 +94,7 @@ class BaseMediaService[T, S]:
         name, _ = self._extract_name_and_year(directory.name)
         candidates = search_func(name, metadata_provider)
         return MediaImportSuggestion(
-            directory=str(directory),
+            directory=directory,
             candidates=candidates,
         )
 
@@ -135,7 +134,7 @@ class BaseMediaService[T, S]:
 
     def import_all_torrents_base(
         self,
-        get_media_func: Callable[[Any], S],
+        get_media_func: Callable[[Any], S | None],
         import_torrent_func: Callable[[Any, S], None],
         media_type_name: str,
     ) -> None:
@@ -153,7 +152,7 @@ class BaseMediaService[T, S]:
         log.info(f"Finished importing all torrents for {media_type_name}")
 
 
-class BaseMetadataService[T, S]:
+class BaseMetadataService[T: Base, S: BaseMedia]:
     """
     Base service for metadata operations.
     """
@@ -206,7 +205,9 @@ class BaseMetadataService[T, S]:
                         external_id=result.external_id,
                         metadata_provider=metadata_provider.name,
                     )
-                    result.id = media.id
+                    # media.id is a plain UUID on BaseMedia; result.id is
+                    # typed as the narrower NewType union MovieId | ShowId.
+                    result.id = media.id  # ty: ignore[invalid-assignment]
                 except Exception:
                     log.exception(
                         f"Unable to find internal ID for {result.external_id} on {metadata_provider.name}"

--- a/media_manager/indexer/indexers/jackett.py
+++ b/media_manager/indexer/indexers/jackett.py
@@ -90,8 +90,10 @@ class Jackett(GenericIndexer, TorznabMixin):
         xml_tree = ET.fromstring(xml)  # noqa: S314  # trusted source, since it is user controlled
         tv_search = xml_tree.find("./*/tv-search")
         movie_search = xml_tree.find("./*/movie-search")
-        log.debug(tv_search.attrib)
-        log.debug(movie_search.attrib)
+        if tv_search is not None:
+            log.debug(tv_search.attrib)
+        if movie_search is not None:
+            log.debug(movie_search.attrib)
 
         tv_search_capabilities = []
         movie_search_capabilities = []
@@ -198,7 +200,7 @@ class Jackett(GenericIndexer, TorznabMixin):
 
     def search_movie(self, query: str, movie: Movie) -> list[IndexerQueryResult]:
         log.debug(f"Searching for movie {movie.name}")
-        params = {
+        params: dict[str, str | int] = {
             "t": "movie",
             "q": query,
         }

--- a/media_manager/indexer/indexers/prowlarr.py
+++ b/media_manager/indexer/indexers/prowlarr.py
@@ -132,7 +132,7 @@ class Prowlarr(GenericIndexer, TorznabMixin):
 
         for indexer in indexers:
             log.debug("Preparing search for indexer: " + indexer.name)
-            search_params = {
+            search_params: dict[str, str | int | None] = {
                 "cat": "5000",
                 "q": query,
                 "t": "tvsearch",
@@ -161,7 +161,7 @@ class Prowlarr(GenericIndexer, TorznabMixin):
         for indexer in indexers:
             log.debug("Preparing search for indexer: " + indexer.name)
 
-            search_params = {
+            search_params: dict[str, str | int | None] = {
                 "cat": "2000",
                 "q": query,
                 "t": "movie",

--- a/media_manager/indexer/indexers/torznab_mixin.py
+++ b/media_manager/indexer/indexers/torznab_mixin.py
@@ -1,6 +1,6 @@
 import logging
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 
 from media_manager.indexer.schemas import IndexerQueryResult
@@ -23,14 +23,16 @@ class TorznabMixin:
                 age = 0
                 indexer_name = "unknown"
 
-                if item.find("jackettindexer") is not None:
-                    indexer_name = item.find("jackettindexer").text
-                if item.find("prowlarrindexer") is not None:
-                    indexer_name = item.find("prowlarrindexer").text
+                if (_indexer := item.find("jackettindexer")) is not None:
+                    indexer_name = _indexer.text
+                if (_indexer := item.find("prowlarrindexer")) is not None:
+                    indexer_name = _indexer.text
 
-                is_usenet = (
-                    item.find("enclosure").attrib["type"] != "application/x-bittorrent"
-                )
+                enclosure = item.find("enclosure")
+                if enclosure is None:
+                    log.warning("Torznab item missing enclosure, skipping.")
+                    continue
+                is_usenet = enclosure.attrib["type"] != "application/x-bittorrent"
 
                 attributes = list(item.findall("torznab:attr", xmlns))
                 for attribute in attributes:
@@ -39,7 +41,7 @@ class TorznabMixin:
                             posted_date = parsedate_to_datetime(
                                 attribute.attrib["value"]
                             )
-                            now = datetime.now(datetime.UTC)
+                            now = datetime.now(UTC)
                             age = int((now - posted_date).total_seconds())
                     else:
                         if attribute.attrib["name"] == "seeders":
@@ -61,7 +63,7 @@ class TorznabMixin:
                             if upload_volume_factor == 2:
                                 flags.append("doubleupload")
 
-                title = item.find("title").text
+                title = t.text if (t := item.find("title")) is not None else None
                 size_str = item.find("size")
                 if size_str is None or size_str.text is None:
                     log.warning(f"Torznab item {title} has no size, skipping.")
@@ -74,7 +76,7 @@ class TorznabMixin:
 
                 result = IndexerQueryResult(
                     title=title or "unknown",
-                    download_url=str(item.find("enclosure").attrib["url"]),
+                    download_url=str(enclosure.attrib["url"]),
                     seeders=seeders,
                     flags=flags,
                     size=size,

--- a/media_manager/indexer/indexers/torznab_mixin.py
+++ b/media_manager/indexer/indexers/torznab_mixin.py
@@ -32,7 +32,14 @@ class TorznabMixin:
                 if enclosure is None:
                     log.warning("Torznab item missing enclosure, skipping.")
                     continue
-                is_usenet = enclosure.attrib["type"] != "application/x-bittorrent"
+                enclosure_type = enclosure.attrib.get("type")
+                enclosure_url = enclosure.attrib.get("url")
+                if enclosure_type is None or enclosure_url is None:
+                    log.warning(
+                        "Torznab item enclosure missing type/url, skipping."
+                    )
+                    continue
+                is_usenet = enclosure_type != "application/x-bittorrent"
 
                 attributes = list(item.findall("torznab:attr", xmlns))
                 for attribute in attributes:
@@ -76,7 +83,7 @@ class TorznabMixin:
 
                 result = IndexerQueryResult(
                     title=title or "unknown",
-                    download_url=str(enclosure.attrib["url"]),
+                    download_url=enclosure_url,
                     seeders=seeders,
                     flags=flags,
                     size=size,

--- a/media_manager/indexer/tests/test_schemas.py
+++ b/media_manager/indexer/tests/test_schemas.py
@@ -1,0 +1,79 @@
+import pytest
+
+from media_manager.torrent.schemas import Quality
+from tests.factories.indexer import make_indexer_result
+
+
+class TestQuality:
+    @pytest.mark.parametrize(
+        "title_prefix",
+        ["Show Title.S01E01", "Movie Title"],
+    )
+    @pytest.mark.parametrize(
+        ("title", "expected"),
+        [
+            (".2160p.WEB-DL", Quality.uhd),
+            (".4K.WEB-DL", Quality.uhd),
+            (".1080p.WEB-DL", Quality.fullhd),
+            (".Full-HD.WEB-DL", Quality.fullhd),
+            (".720p.WEB-DL", Quality.hd),
+            (".480p.WEB-DL", Quality.sd),
+            (".WEB-DL", Quality.unknown),
+        ],
+    )
+    def test_quality_inferred_from_title(
+        self, title_prefix: str, title: str, expected: Quality
+    ) -> None:
+        result = make_indexer_result(title=title_prefix + title)
+        assert result.quality == expected
+
+
+class TestSeason:
+    @pytest.mark.parametrize(
+        ("title", "expected"),
+        [
+            ("Show.S01E01", [1]),
+            ("Show.S03E12.1080p", [3]),
+            ("Show.S01-S03.Complete", [1, 2, 3]),
+            ("Show Season 2 1080p", [2]),
+            ("Show.S05.Complete", [5]),
+            ("Show.Random.Title", []),
+        ],
+    )
+    def test_season_extraction(self, title: str, expected: list[int]) -> None:
+        assert make_indexer_result(title=title).season == expected
+
+
+class TestEpisode:
+    @pytest.mark.parametrize(
+        ("title", "expected"),
+        [
+            ("Show.S01E01", [1]),
+            ("Show.S01E01-S01E03", [1, 2, 3]),
+            ("Show.S01E05-07", [5, 6, 7]),
+            ("Show.S01.Complete", []),
+        ],
+    )
+    def test_episode_extraction(self, title: str, expected: list[int]) -> None:
+        assert make_indexer_result(title=title).episode == expected
+
+
+class TestOrdering:
+    def test_higher_quality_sorts_first(self) -> None:
+        # __gt__ on IndexerQueryResult means "better than"; sorting in
+        # descending order puts the best result first.
+        uhd = make_indexer_result(title="SomeName.S01E01.2160p")
+        hd = make_indexer_result(title="SomeName.S01E01.1080p")
+        sd = make_indexer_result(title="SomeName.S01E01.480p")
+        ordered = sorted([sd, uhd, hd], reverse=True)
+        assert [r.quality for r in ordered] == [Quality.uhd, Quality.fullhd, Quality.sd]
+
+    def test_same_quality_higher_score_first(self) -> None:
+        a = make_indexer_result(title="SomeName.S01E01.1080p", score=100)
+        b = make_indexer_result(title="OtherName.S01E01.1080p", score=50)
+        assert sorted([b, a], reverse=True)[0].score == 100
+
+    def test_same_quality_and_score_higher_seeders_first(self) -> None:
+        a = make_indexer_result(title="SomeName.S01E01.1080p", seeders=200)
+        b = make_indexer_result(title="OtherName.S01E01.1080p", seeders=10)
+        assert sorted([b, a], reverse=True)[0].seeders == 200

--- a/media_manager/indexer/tests/test_scoring.py
+++ b/media_manager/indexer/tests/test_scoring.py
@@ -1,0 +1,133 @@
+from media_manager.indexer.config import (
+    IndexerFlagScoringRule,
+    ScoringRuleSet,
+    TitleScoringRule,
+)
+from media_manager.indexer.utils import evaluate_indexer_query_result
+from tests.factories.indexer import make_indexer_result
+from tests.types import PatchScoringRules
+
+
+class TestEvaluateIndexerQueryResult:
+    def test_title_keyword_match_adds_score(
+        self, patch_scoring_rules: PatchScoringRules
+    ) -> None:
+        patch_scoring_rules(
+            title=[
+                TitleScoringRule(
+                    name="prefer_h265",
+                    keywords=["h265", "x265"],
+                    score_modifier=100,
+                ),
+            ],
+        )
+        result = make_indexer_result(title="Show.S01E01.1080p.x265-RELEASE", score=0)
+        ruleset = ScoringRuleSet(name="rs", rule_names=["prefer_h265"])
+
+        scored, passed = evaluate_indexer_query_result(result, ruleset)
+
+        assert scored.score == 100
+        assert passed is True
+
+    def test_title_keyword_miss_leaves_score_alone(
+        self, patch_scoring_rules: PatchScoringRules
+    ) -> None:
+        patch_scoring_rules(
+            title=[
+                TitleScoringRule(
+                    name="prefer_h265",
+                    keywords=["h265"],
+                    score_modifier=100,
+                ),
+            ],
+        )
+        result = make_indexer_result(title="Show.S01E01.1080p.x264-RELEASE", score=0)
+        ruleset = ScoringRuleSet(name="rs", rule_names=["prefer_h265"])
+
+        scored, passed = evaluate_indexer_query_result(result, ruleset)
+
+        # Score stays at 0 — evaluate_indexer_query_result returns
+        # passed=False when score <= 0.
+        assert scored.score == 0
+        assert passed is False
+
+    def test_negate_rule_fires_when_keyword_absent(
+        self, patch_scoring_rules: PatchScoringRules
+    ) -> None:
+        patch_scoring_rules(
+            title=[
+                TitleScoringRule(
+                    name="require_freeleech_word",
+                    keywords=["freeleech"],
+                    score_modifier=-10_000,
+                    negate=True,
+                ),
+            ],
+        )
+        result = make_indexer_result(title="Show.S01E01.1080p", score=50)
+        ruleset = ScoringRuleSet(name="rs", rule_names=["require_freeleech_word"])
+
+        scored, passed = evaluate_indexer_query_result(result, ruleset)
+
+        assert scored.score == 50 - 10_000
+        assert passed is False
+
+    def test_word_boundary_prevents_substring_match(
+        self, patch_scoring_rules: PatchScoringRules
+    ) -> None:
+        # "ts" must not match "torrents"; this is the exact regression the
+        # \b boundaries in evaluate_indexer_query_result are there to prevent.
+        patch_scoring_rules(
+            title=[
+                TitleScoringRule(
+                    name="avoid_ts",
+                    keywords=["ts"],
+                    score_modifier=-10_000,
+                ),
+            ],
+        )
+        result = make_indexer_result(title="Show.S01E01.from.torrents.1080p", score=100)
+        ruleset = ScoringRuleSet(name="rs", rule_names=["avoid_ts"])
+
+        scored, _ = evaluate_indexer_query_result(result, ruleset)
+        assert scored.score == 100
+
+    def test_indexer_flag_rule_match_subtracts_score(
+        self, patch_scoring_rules: PatchScoringRules
+    ) -> None:
+        patch_scoring_rules(
+            flags=[
+                IndexerFlagScoringRule(
+                    name="reject_nuked",
+                    flags=["nuked"],
+                    score_modifier=-10_000,
+                ),
+            ],
+        )
+        result = make_indexer_result(
+            title="Show.S01E01.1080p", flags=["nuked"], score=200
+        )
+        ruleset = ScoringRuleSet(name="rs", rule_names=["reject_nuked"])
+
+        scored, passed = evaluate_indexer_query_result(result, ruleset)
+
+        assert scored.score == 200 - 10_000
+        assert passed is False
+
+    def test_unknown_rule_name_is_ignored(
+        self, patch_scoring_rules: PatchScoringRules
+    ) -> None:
+        patch_scoring_rules(
+            title=[
+                TitleScoringRule(
+                    name="prefer_h265", keywords=["h265"], score_modifier=100
+                ),
+            ],
+        )
+        result = make_indexer_result(title="Show.S01E01.x265", score=10)
+        ruleset = ScoringRuleSet(name="rs", rule_names=["does_not_exist"])
+
+        scored, passed = evaluate_indexer_query_result(result, ruleset)
+
+        assert scored.score == 10
+        assert passed is True

--- a/media_manager/main.py
+++ b/media_manager/main.py
@@ -144,12 +144,12 @@ async def hello_world() -> dict:
 
 
 api_app.include_router(
-    fastapi_users.get_auth_router(bearer_auth_backend),
+    fastapi_users.get_auth_router(bearer_auth_backend),  # ty: ignore[invalid-argument-type]
     prefix="/auth/jwt",
     tags=["auth"],
 )
 api_app.include_router(
-    fastapi_users.get_auth_router(cookie_auth_backend),
+    fastapi_users.get_auth_router(cookie_auth_backend),  # ty: ignore[invalid-argument-type]
     prefix="/auth/cookie",
     tags=["auth"],
 )

--- a/media_manager/movies/importer.py
+++ b/media_manager/movies/importer.py
@@ -35,7 +35,7 @@ class MovieImportService(BaseMediaService[Movie, Movie]):
         super().__init__(
             repository=movie_repository,
             torrent_service=torrent_service,
-            indexer_service=None,  # type: ignore[arg-type]
+            indexer_service=None,  # ty: ignore[invalid-argument-type]
             notification_service=notification_service,
         )
         self.movie_repository = movie_repository
@@ -122,7 +122,7 @@ class MovieImportService(BaseMediaService[Movie, Movie]):
     def get_import_candidates(
         self, movie_path: Path, metadata_provider: AbstractMetadataProvider
     ) -> MediaImportSuggestion:
-        return super().get_import_candidates(
+        return super()._get_import_candidates_base(
             directory=movie_path,
             metadata_provider=metadata_provider,
             search_func=self.movie_metadata_service.search_for_movie,

--- a/media_manager/movies/service.py
+++ b/media_manager/movies/service.py
@@ -88,7 +88,7 @@ class MovieService(BaseMediaService[Movie, Movie]):
                         self.torrent_service.cancel_download(
                             torrent=torrent, delete_files=True
                         )
-                        log.info(f"Deleted torrent: {torrent.torrent_title}")
+                        log.info(f"Deleted torrent: {torrent.title}")
                     except Exception:
                         log.exception(f"Failed to delete torrent {torrent.hash}")
 

--- a/media_manager/notification/repository.py
+++ b/media_manager/notification/repository.py
@@ -1,6 +1,7 @@
 import logging
+from typing import cast
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import CursorResult, delete, select, update
 from sqlalchemy.exc import (
     IntegrityError,
     SQLAlchemyError,
@@ -90,7 +91,7 @@ class NotificationRepository:
 
     def delete_notification(self, nid: NotificationId) -> None:
         stmt = delete(Notification).where(Notification.id == nid)
-        result = self.db.execute(stmt)
+        result = cast(CursorResult, self.db.execute(stmt))
         if result.rowcount == 0:
             msg = f"Notification with id {nid} not found."
             raise NotFoundError(msg)

--- a/media_manager/torrent/download_clients/qbittorrent.py
+++ b/media_manager/torrent/download_clients/qbittorrent.py
@@ -60,7 +60,9 @@ class QbittorrentDownloadClient(AbstractDownloadClient):
         categories = self.api_client.torrents_categories()
         log.debug(f"Found following categories in qBittorrent: {categories}")
         if self.config.category_name in categories:
-            category = categories.get(self.config.category_name)
+            # torrents_categories returns a Divergent type tree; the value
+            # under a known category is always a dict in practice.
+            category: dict = categories.get(self.config.category_name)  # ty: ignore[invalid-assignment]
             if category.get("savePath") == self.config.category_save_path:
                 log.debug(
                     f"Category '{self.config.category_name}' already exists in qBittorrent with the correct save path."
@@ -172,7 +174,9 @@ class QbittorrentDownloadClient(AbstractDownloadClient):
         if not info:
             log.warning(f"No information found for torrent: {torrent.id}")
             return TorrentStatus.unknown
-        state: str = info[0]["state"]
+        # torrents_info entries expose state as str at runtime; the stub
+        # type is a union covering raw API shapes.
+        state: str = info[0]["state"]  # ty: ignore[invalid-assignment]
 
         if state in self.DOWNLOADING_STATE:
             return TorrentStatus.downloading

--- a/media_manager/torrent/tests/test_utils.py
+++ b/media_manager/torrent/tests/test_utils.py
@@ -1,0 +1,61 @@
+import pytest
+
+from media_manager.torrent.utils import (
+    extract_external_id_from_string,
+    remove_special_characters,
+    remove_special_chars_and_parentheses,
+)
+
+
+class TestRemoveSpecialCharacters:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("normal title", "normal title"),
+            ('weird:"/\\|?*name', "weirdname"),
+            ("Show <2024>", "Show 2024"),
+            ("  spaced.  ", "spaced"),
+            ("....leading.dots", "leading.dots"),
+        ],
+    )
+    def test_strips_invalid_chars_and_trims(self, raw: str, expected: str) -> None:
+        assert remove_special_characters(raw) == expected
+
+
+class TestRemoveSpecialCharsAndParentheses:
+    def test_strips_year_in_parens(self) -> None:
+        assert remove_special_chars_and_parentheses("The Show (2024)") == "The Show"
+
+    def test_strips_square_and_curly_bracket_groups(self) -> None:
+        assert remove_special_chars_and_parentheses("Show [1080p] {x265}") == "Show"
+
+    def test_collapses_whitespace(self) -> None:
+        assert (
+            remove_special_chars_and_parentheses("Show   Name    (2024)") == "Show Name"
+        )
+
+    def test_keeps_non_year_parentheses(self) -> None:
+        # The year-in-parens rule only matches exactly 4 digits; other
+        # parenthesized content is left intact (parens aren't in the
+        # special-character set).
+        assert remove_special_chars_and_parentheses("Show (US)") == "Show (US)"
+
+
+class TestExtractExternalIdFromString:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("Some Show tmdb-12345", ("tmdb", 12345)),
+            ("Movie {tvdbid-67890}", ("tvdb", 67890)),
+            ("Folder name TMDB_42 here", ("tmdb", 42)),
+            ("show.tvdb-99", ("tvdb", 99)),
+        ],
+    )
+    def test_finds_known_providers(self, raw: str, expected: tuple[str, int]) -> None:
+        assert extract_external_id_from_string(raw) == expected
+
+    def test_returns_none_when_absent(self) -> None:
+        assert extract_external_id_from_string("plain folder name") == (None, None)
+
+    def test_returns_none_for_unknown_provider(self) -> None:
+        assert extract_external_id_from_string("imdb-12345") == (None, None)

--- a/media_manager/tv/importer.py
+++ b/media_manager/tv/importer.py
@@ -11,7 +11,7 @@ from media_manager.metadataProvider.abstract_metadata_provider import (
 )
 from media_manager.notification.service import NotificationService
 from media_manager.schemas import MediaImportSuggestion
-from media_manager.torrent.schemas import Quality, Torrent
+from media_manager.torrent.schemas import Quality, Torrent, TorrentId
 from media_manager.torrent.service import TorrentService
 from media_manager.torrent.utils import (
     get_files_for_import,
@@ -37,7 +37,7 @@ class TvImportService(BaseMediaService[Show, Show]):
         super().__init__(
             repository=tv_repository,
             torrent_service=torrent_service,
-            indexer_service=None,  # type: ignore[arg-type]
+            indexer_service=None,  # ty: ignore[invalid-argument-type]
             notification_service=notification_service,
         )
         self.tv_repository = tv_repository
@@ -56,7 +56,7 @@ class TvImportService(BaseMediaService[Show, Show]):
         show: Show,
         source_directory: Path,
         quality: Quality = Quality.unknown,
-        torrent_id: str | None = None,
+        torrent_id: TorrentId | None = None,
         file_path_suffix: str = "",
     ) -> bool:
         video_files, _, _ = get_files_for_import(directory=source_directory)
@@ -118,7 +118,7 @@ class TvImportService(BaseMediaService[Show, Show]):
     def get_import_candidates(
         self, tv_path: Path, metadata_provider: AbstractMetadataProvider
     ) -> MediaImportSuggestion:
-        return super().get_import_candidates(
+        return super()._get_import_candidates_base(
             directory=tv_path,
             metadata_provider=metadata_provider,
             search_func=self.tv_metadata_service.search_for_show,

--- a/media_manager/tv/service.py
+++ b/media_manager/tv/service.py
@@ -22,6 +22,7 @@ from media_manager.tv.schemas import (
     EpisodeFile,
     EpisodeId,
     EpisodeNumber,
+    PublicEpisode,
     PublicEpisodeFile,
     PublicSeason,
     PublicShow,
@@ -220,7 +221,7 @@ class TvService(BaseMediaService[Show, Show]):
         return True
 
     def is_episode_downloaded(
-        self, episode: Episode, season: Season, show: Show
+        self, episode: Episode | PublicEpisode, season: Season, show: Show
     ) -> bool:
         """
         Check if an episode is downloaded and imported (file exists on disk).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "taskiq-fastapi>=0.4.0",
     "taskiq-postgresql[psycopg]>=0.4.0",
     "alembic>=1.16.1",
-    "pytest>=8.4.0",
     "pillow>=11.3.0",
     "sabnzbd-api>=0.1.2",
     "transmission-rpc>=7.0.11",
@@ -43,8 +42,23 @@ dependencies = [
 dev = [
     "ruff",
     "ty>=0.0.33",
+    "pytest>=9.0.3,<10.0.0",
+    "pytest-asyncio>=1.3.0,<2.0.0",
 ]
 
 [tool.setuptools.packages.find]
 include = ["media_manager*"]
-exclude = ["web*", "Writerside*", "metadata_relay*", "tests*"]
+exclude = ["web*", "Writerside*", "metadata_relay*", "tests*", "media_manager/**/tests*"]
+
+[tool.pytest.ini_options]
+# Unit tests live next to source under `media_manager/<feature>/tests/`.
+# Integration / DB / API tests live in `tests/`.
+testpaths = ["media_manager", "tests"]
+pythonpath = ["."]
+python_files = ["test_*.py"]
+addopts = "-ra --strict-markers"
+markers = [
+    "db: requires a test database (backend selected by fixtures via TEST_DATABASE_URL)",
+    "indexer: hits a real indexer; requires INDEXER_CONFIG",
+]
+asyncio_mode = "strict"

--- a/ruff.toml
+++ b/ruff.toml
@@ -42,3 +42,17 @@ ignore = [
 
 [lint.flake8-bugbear]
 extend-immutable-calls = ["fastapi.Depends", "fastapi.Path", "taskiq.TaskiqDepends"]
+
+[lint.per-file-ignores]
+# Tests use bare `assert`, magic numbers/literal credentials are part of
+# the test payload, and `**overrides: Any` is the standard factory shape.
+# Everything else — including full annotations on fixtures and tests — is
+# enforced the same as production code.
+# Unit tests live next to source (media_manager/<feature>/tests/); the
+# tests/ tree holds shared factories and (future) integration tests.
+"{conftest.py,tests/**/*.py,media_manager/*/tests/**/*.py}" = [
+    "S101", "S105", "S106",       # bare assert + literal "password"/"secret" args are fine in tests
+    "ANN401",                     # **overrides: Any is the standard factory signature
+    "PLR2004",                    # magic numbers are the test payload
+    "INP001",                     # __init__.py-less subpkgs are intentional under tests/
+]

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client() -> TestClient:
+    # Import inside the fixture so CONFIG_FILE / DISABLE_FRONTEND_MOUNT (set
+    # by the root conftest) are in place before main.py runs at import time.
+    from media_manager.main import app
+
+    return TestClient(app)

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,45 @@
+"""Bare Minimum smoke tests for FastAPI app: the app boots,
+the health endpoint responds, OpenAPI is generated,
+and protected endpoints reject anonymous requests.
+"""
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+
+class TestHealth:
+    def test_health_endpoint_returns_message(self, client: TestClient) -> None:
+        response = client.get("/api/v1/health")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert "Hello World" in body["message"]
+        # version comes from PUBLIC_VERSION; unset in tests → None
+        assert "version" in body
+
+
+class TestOpenAPI:
+    def test_openapi_schema_is_served(self, client: TestClient) -> None:
+        response = client.get("/openapi.json")
+
+        assert response.status_code == status.HTTP_200_OK
+        schema = response.json()
+        assert schema["openapi"].startswith("3.")
+        assert "/api/v1/health" in schema["paths"]
+
+    def test_known_routers_are_mounted(self, client: TestClient) -> None:
+        # Surface-level guard against an accidentally-removed include_router
+        # call in main.py. Doesn't validate individual endpoint shapes.
+        paths = client.get("/openapi.json").json()["paths"]
+        assert any(p.startswith("/api/v1/tv/") for p in paths)
+        assert any(p.startswith("/api/v1/movies/") for p in paths)
+        assert any(p.startswith("/api/v1/torrent") for p in paths)
+        assert any(p.startswith("/api/v1/notification") for p in paths)
+
+
+class TestAuthGate:
+    def test_protected_endpoint_rejects_anonymous(self, client: TestClient) -> None:
+        # /api/v1/tv/shows requires current_active_user. Anonymous request
+        # should be rejected; fastapi-users returns 401.
+        response = client.get("/api/v1/tv/shows")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/factories/indexer.py
+++ b/tests/factories/indexer.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from media_manager.indexer.schemas import IndexerQueryResult
+
+
+def make_indexer_result(**overrides: Any) -> IndexerQueryResult:
+    """Build an IndexerQueryResult with sensible defaults.
+
+    Pass kwargs to override individual fields.
+    """
+    defaults: dict[str, Any] = {
+        "title": "Some.Show.S01E01.1080p.WEB-DL.x265-RELEASE",
+        "download_url": "magnet:?xt=urn:btih:0000000000000000000000000000000000000000",
+        "seeders": 10,
+        "flags": [],
+        "size": 1_500_000_000,
+        "usenet": False,
+        "age": 0,
+        "indexer": "test",
+    }
+    return IndexerQueryResult(**{**defaults, **overrides})

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,0 +1,16 @@
+from typing import Protocol
+
+from media_manager.indexer.config import (
+    IndexerFlagScoringRule,
+    TitleScoringRule,
+)
+
+
+class PatchScoringRules(Protocol):
+    """Signature of the `patch_scoring_rules` fixture."""
+
+    def __call__(
+        self,
+        title: list[TitleScoringRule] | None = None,
+        flags: list[IndexerFlagScoringRule] | None = None,
+    ) -> None: ...

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,6 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings", extra = ["toml"] },
-    { name = "pytest" },
     { name = "python-json-logger" },
     { name = "qbittorrent-api" },
     { name = "requests" },
@@ -1065,6 +1064,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1088,7 +1089,6 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "pydantic-settings", extras = ["toml"], specifier = ">=2.9.1" },
-    { name = "pytest", specifier = ">=8.4.0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "qbittorrent-api", specifier = ">=2025.5.0" },
     { name = "requests", specifier = ">=2.32.3" },
@@ -1108,6 +1108,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
     { name = "ruff" },
     { name = "ty", specifier = ">=0.0.33" },
 ]
@@ -1605,7 +1607,7 @@ crypto = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1614,9 +1616,21 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hey! 
While implementing #541 i was really missed quick way to make sure to check that the repo is operational / type checked.

- Tests (just baseline): Add simple unit tests and api tests
- Type checking: I see you are using `ty` already, fixed all 72 errors 
- CI: Added separate workflow with python tests; call it from the main build-push ci
- Docs: mention `ty` in docs
 
NOT included: proper api test, db tests, e2e test -- the main gold pf this PR is not discuss and make a foundation to build on + enable auto-testing in ci.

That would be great if you can take a look! @maxdorninger
Thanks!  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad test suites for indexer quality, season/episode parsing, scoring rules, torrent utilities, API health/auth, and test factories/fixtures.

* **Bug Fixes**
  * Improved indexer XML parsing to safely handle missing elements.
  * Fixed torrent deletion logging to reference the correct field.

* **Documentation**
  * Expanded developer guide with formatting, linting, type-checking, and test-running instructions.

* **Chores**
  * Added CI workflow for backend tests and linting; reused it from build workflow. Updated lint/test tooling and per-file lint ignores.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxdorninger/MediaManager/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->