### PR TITLE
Add rtorrent/rutorrent support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -105,6 +105,17 @@ host = "localhost"
 port = 9091
 path = "/transmission/rpc" # RPC request path target, usually "/transmission/rpc"
 
+# rTorrent / ruTorrent settings
+[torrents.rtorrent]
+enabled = false
+host = "localhost"
+port = 8080
+path = "/RPC2"           # XML-RPC endpoint exposed by ruTorrent/the web server
+https_enabled = false
+username = ""
+password = ""
+label = "MediaManager"  # stored in rTorrent's custom1 field, like a category
+
 # SABnzbd settings
 [torrents.sabnzbd]
 enabled = false

--- a/docs/configuration/download-clients.md
+++ b/docs/configuration/download-clients.md
@@ -1,6 +1,6 @@
 # Download Clients
 
-Download client settings are configured in the `[torrents]` section of your `config.toml` file. MediaManager supports both qBittorrent and SABnzbd as download clients.
+Download client settings are configured in the `[torrents]` section of your `config.toml` file. MediaManager supports qBittorrent, Transmission and rTorrent/ruTorrent as torrent clients, and SABnzbd as a Usenet client.
 
 ## qBittorrent Settings (`[torrents.qbittorrent]`)
 
@@ -38,6 +38,33 @@ Transmission is a BitTorrent client that MediaManager can integrate with for dow
   Port of the Transmission RPC endpoint. Default is `9091`.
 * `path`\
   RPC request path target. Usually `/transmission/rpc`.
+
+## rTorrent / ruTorrent Settings (`[torrents.rtorrent]`)
+
+!!! info
+    MediaManager talks to rTorrent through its XML-RPC interface. ruTorrent is only a web UI on top of rTorrent, so configure the XML-RPC endpoint that ruTorrent (or your web server) exposes — usually `/RPC2`.
+
+!!! info
+    The downloads path in rTorrent and MediaManager must be the same, i.e. the path `/data/torrents` must link to the same volume for both containers.
+
+rTorrent is a BitTorrent client (commonly paired with the ruTorrent web UI) that MediaManager can integrate with for downloading torrents.
+
+* `enabled`\
+  Set to `true` to enable rTorrent integration. Default is `false`.
+* `host`\
+  Hostname or IP of the rTorrent/ruTorrent server (without protocol).
+* `port`\
+  Port of the XML-RPC endpoint. Default is `8080`.
+* `path`\
+  Path of the XML-RPC endpoint. Usually `/RPC2`. Default is `/RPC2`.
+* `https_enabled`\
+  Set to `true` if your XML-RPC endpoint uses HTTPS. Default is `false`.
+* `username`\
+  Username for HTTP authentication. Leave empty if not required.
+* `password`\
+  Password for HTTP authentication. Leave empty if not required.
+* `label`\
+  Label stored in rTorrent's `custom1` field (the ruTorrent label), similar to a qBittorrent category. Default is `MediaManager`.
 
 ## SABnzbd Settings (`[torrents.sabnzbd]`)
 
@@ -77,6 +104,17 @@ Here's a complete example of the download clients section in your `config.toml`:
     host = "transmission"
     port = 9091
     path = "/transmission/rpc"
+
+    # rTorrent / ruTorrent configuration
+    [torrents.rtorrent]
+    enabled = false
+    host = "rtorrent"
+    port = 8080
+    path = "/RPC2"
+    https_enabled = false
+    username = ""
+    password = ""
+    label = "MediaManager"
 
     # SABnzbd configuration
     [torrents.sabnzbd]

--- a/media_manager/logging.py
+++ b/media_manager/logging.py
@@ -83,4 +83,5 @@ def setup_logging() -> None:
     logging.getLogger("transmission_rpc").setLevel(logging.WARNING)
     logging.getLogger("qbittorrentapi").setLevel(logging.WARNING)
     logging.getLogger("sabnzbd_api").setLevel(logging.WARNING)
+    logging.getLogger("pyrosimple").setLevel(logging.WARNING)
     logging.getLogger("taskiq").setLevel(logging.WARNING)

--- a/media_manager/torrent/config.py
+++ b/media_manager/torrent/config.py
@@ -22,6 +22,17 @@ class TransmissionConfig(BaseSettings):
     enabled: bool = False
 
 
+class RtorrentConfig(BaseSettings):
+    host: str = "localhost"
+    port: int = 8080
+    path: str = "/RPC2"  # XML-RPC endpoint exposed by ruTorrent/the web server
+    https_enabled: bool = False
+    username: str = ""
+    password: str = ""
+    enabled: bool = False
+    label: str = "MediaManager"  # stored in rTorrent's d.custom1, like a category
+
+
 class SabnzbdConfig(BaseSettings):
     host: str = "localhost"
     port: int = 8080
@@ -33,4 +44,5 @@ class SabnzbdConfig(BaseSettings):
 class TorrentConfig(BaseSettings):
     qbittorrent: QbittorrentConfig = QbittorrentConfig()
     transmission: TransmissionConfig = TransmissionConfig()
+    rtorrent: RtorrentConfig = RtorrentConfig()
     sabnzbd: SabnzbdConfig = SabnzbdConfig()

--- a/media_manager/torrent/download_clients/rtorrent.py
+++ b/media_manager/torrent/download_clients/rtorrent.py
@@ -1,11 +1,16 @@
 import logging
 import shutil
+import time
+import xmlrpc.client
 from urllib.parse import quote
 
 import pyrosimple
+import requests
+from requests.exceptions import InvalidSchema
 
 from media_manager.config import MediaManagerConfig
 from media_manager.indexer.schemas import IndexerQueryResult
+from media_manager.indexer.utils import follow_redirects_to_final_torrent_url
 from media_manager.torrent.download_clients.abstract_download_client import (
     AbstractDownloadClient,
 )
@@ -13,6 +18,11 @@ from media_manager.torrent.schemas import Torrent, TorrentStatus
 from media_manager.torrent.utils import get_torrent_filepath, get_torrent_hash
 
 log = logging.getLogger(__name__)
+
+# rTorrent loads torrents asynchronously, so wait for the download to register
+# before returning (callers may immediately pause/query it by info-hash).
+_REGISTRATION_TIMEOUT_SECONDS = 15.0
+_REGISTRATION_POLL_SECONDS = 0.5
 
 
 class RtorrentDownloadClient(AbstractDownloadClient):
@@ -47,21 +57,22 @@ class RtorrentDownloadClient(AbstractDownloadClient):
         download_dir = (
             MediaManagerConfig().misc.torrent_directory / indexer_result.title
         )
+        # The empty first argument is the load target. The download directory and
+        # ruTorrent label (d.custom1) are applied as part of the load command.
+        commands = (
+            f'd.directory.set="{download_dir}"',
+            f'd.custom1.set="{self.config.label}"',
+        )
         try:
-            # rTorrent fetches the .torrent/magnet from the URL itself, like the
-            # other clients. The empty first argument is the load target.
-            self._engine.rpc.load.start(
-                "",
-                str(indexer_result.download_url),
-                f'd.directory.set="{download_dir}"',
-                f'd.custom1.set="{self.config.label}"',
-            )
-
+            self._load(indexer_result, commands)
             log.info(f"Successfully added torrent to rTorrent: {indexer_result.title}")
-
         except Exception:
             log.exception("Failed to add torrent to rTorrent")
             raise
+
+        # rTorrent registers the download asynchronously; wait so that the caller
+        # can immediately query or pause it by info-hash.
+        self._wait_until_registered(torrent_hash)
 
         torrent = Torrent(
             status=TorrentStatus.unknown,
@@ -75,6 +86,53 @@ class RtorrentDownloadClient(AbstractDownloadClient):
         torrent.status = self.get_torrent_status(torrent)
 
         return torrent
+
+    def _load(self, indexer_result: IndexerQueryResult, commands: tuple[str, ...]) -> None:
+        """
+        Load a torrent into rTorrent.
+
+        Unlike qBittorrent/Transmission, rTorrent cannot follow an HTTP redirect
+        to a magnet link, so the download URL is resolved here (mirroring
+        get_torrent_hash): magnet links are loaded as-is, .torrent files are
+        downloaded and pushed as raw data so the download registers immediately.
+        """
+        download_url = str(indexer_result.download_url)
+        if download_url.startswith("magnet:"):
+            self._engine.rpc.load.start("", download_url, *commands)
+            return
+
+        try:
+            response = requests.get(download_url, timeout=30)
+            response.raise_for_status()
+        except InvalidSchema:
+            # The URL redirected to a magnet link, which requests cannot fetch.
+            magnet = follow_redirects_to_final_torrent_url(
+                initial_url=indexer_result.download_url,
+                session=requests.Session(),
+                timeout=MediaManagerConfig().indexers.prowlarr.timeout_seconds,
+            )
+            self._engine.rpc.load.start("", magnet, *commands)
+            return
+
+        self._engine.rpc.load.raw_start(
+            "", xmlrpc.client.Binary(response.content), *commands
+        )
+
+    def _wait_until_registered(self, torrent_hash: str) -> None:
+        """Wait until rTorrent has registered the download for the given hash."""
+        target_hash = torrent_hash.upper()
+        deadline = time.monotonic() + _REGISTRATION_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            try:
+                if target_hash in self._engine.rpc.download_list():
+                    return
+            except Exception:
+                log.debug("Failed to fetch download list while waiting", exc_info=True)
+            time.sleep(_REGISTRATION_POLL_SECONDS)
+        log.warning(
+            f"Torrent {target_hash} did not register in rTorrent within "
+            f"{_REGISTRATION_TIMEOUT_SECONDS}s"
+        )
 
     def remove_torrent(self, torrent: Torrent, delete_data: bool = False) -> None:
         """

--- a/media_manager/torrent/download_clients/rtorrent.py
+++ b/media_manager/torrent/download_clients/rtorrent.py
@@ -57,22 +57,24 @@ class RtorrentDownloadClient(AbstractDownloadClient):
         download_dir = (
             MediaManagerConfig().misc.torrent_directory / indexer_result.title
         )
-        # The empty first argument is the load target. The download directory and
-        # ruTorrent label (d.custom1) are applied as part of the load command.
-        commands = (
-            f'd.directory.set="{download_dir}"',
-            f'd.custom1.set="{self.config.label}"',
-        )
         try:
-            self._load(indexer_result, commands)
+            # Load the torrent stopped, then configure and start it. The download
+            # directory and label are passed as proper XML-RPC arguments (not
+            # embedded in load command strings) so that values coming from the
+            # indexer (e.g. the title) cannot break out or inject commands.
+            self._load(indexer_result)
+            # rTorrent registers the download asynchronously.
+            self._wait_until_registered(torrent_hash)
+
+            target_hash = torrent_hash.upper()
+            self._engine.rpc.d.directory.set(target_hash, str(download_dir))
+            self._engine.rpc.d.custom1.set(target_hash, self.config.label)
+            self._engine.rpc.d.start(target_hash)
+
             log.info(f"Successfully added torrent to rTorrent: {indexer_result.title}")
         except Exception:
             log.exception("Failed to add torrent to rTorrent")
             raise
-
-        # rTorrent registers the download asynchronously; wait so that the caller
-        # can immediately query or pause it by info-hash.
-        self._wait_until_registered(torrent_hash)
 
         torrent = Torrent(
             status=TorrentStatus.unknown,
@@ -87,18 +89,19 @@ class RtorrentDownloadClient(AbstractDownloadClient):
 
         return torrent
 
-    def _load(self, indexer_result: IndexerQueryResult, commands: tuple[str, ...]) -> None:
+    def _load(self, indexer_result: IndexerQueryResult) -> None:
         """
-        Load a torrent into rTorrent.
+        Load a torrent into rTorrent in a stopped state.
 
         Unlike qBittorrent/Transmission, rTorrent cannot follow an HTTP redirect
         to a magnet link, so the download URL is resolved here (mirroring
         get_torrent_hash): magnet links are loaded as-is, .torrent files are
-        downloaded and pushed as raw data so the download registers immediately.
+        downloaded and pushed as raw data. Loading stopped lets the caller set
+        the download directory before the download starts.
         """
         download_url = str(indexer_result.download_url)
         if download_url.startswith("magnet:"):
-            self._engine.rpc.load.start("", download_url, *commands)
+            self._engine.rpc.load.normal("", download_url)
             return
 
         try:
@@ -111,15 +114,17 @@ class RtorrentDownloadClient(AbstractDownloadClient):
                 session=requests.Session(),
                 timeout=MediaManagerConfig().indexers.prowlarr.timeout_seconds,
             )
-            self._engine.rpc.load.start("", magnet, *commands)
+            self._engine.rpc.load.normal("", magnet)
             return
 
-        self._engine.rpc.load.raw_start(
-            "", xmlrpc.client.Binary(response.content), *commands
-        )
+        self._engine.rpc.load.raw("", xmlrpc.client.Binary(response.content))
 
     def _wait_until_registered(self, torrent_hash: str) -> None:
-        """Wait until rTorrent has registered the download for the given hash."""
+        """
+        Wait until rTorrent has registered the download for the given hash.
+
+        :raises RuntimeError: If the download does not register before the timeout.
+        """
         target_hash = torrent_hash.upper()
         deadline = time.monotonic() + _REGISTRATION_TIMEOUT_SECONDS
         while time.monotonic() < deadline:
@@ -129,10 +134,11 @@ class RtorrentDownloadClient(AbstractDownloadClient):
             except Exception:
                 log.debug("Failed to fetch download list while waiting", exc_info=True)
             time.sleep(_REGISTRATION_POLL_SECONDS)
-        log.warning(
+        msg = (
             f"Torrent {target_hash} did not register in rTorrent within "
             f"{_REGISTRATION_TIMEOUT_SECONDS}s"
         )
+        raise RuntimeError(msg)
 
     def remove_torrent(self, torrent: Torrent, delete_data: bool = False) -> None:
         """

--- a/media_manager/torrent/download_clients/rtorrent.py
+++ b/media_manager/torrent/download_clients/rtorrent.py
@@ -1,0 +1,159 @@
+import logging
+import shutil
+from urllib.parse import quote
+
+import pyrosimple
+
+from media_manager.config import MediaManagerConfig
+from media_manager.indexer.schemas import IndexerQueryResult
+from media_manager.torrent.download_clients.abstract_download_client import (
+    AbstractDownloadClient,
+)
+from media_manager.torrent.schemas import Torrent, TorrentStatus
+from media_manager.torrent.utils import get_torrent_filepath, get_torrent_hash
+
+log = logging.getLogger(__name__)
+
+
+class RtorrentDownloadClient(AbstractDownloadClient):
+    name = "rtorrent"
+
+    def __init__(self) -> None:
+        self.config = MediaManagerConfig().torrents.rtorrent
+
+        scheme = "https" if self.config.https_enabled else "http"
+        credentials = ""
+        if self.config.username:
+            credentials = f"{quote(self.config.username)}:{quote(self.config.password)}@"
+        path = self.config.path if self.config.path.startswith("/") else f"/{self.config.path}"
+        url = f"{scheme}://{credentials}{self.config.host}:{self.config.port}{path}"
+
+        try:
+            self._engine = pyrosimple.connect(url)
+            # Test connection
+            self._engine.rpc.system.client_version()
+        except Exception:
+            log.exception("Failed to connect to rTorrent")
+            raise
+
+    def download_torrent(self, indexer_result: IndexerQueryResult) -> Torrent:
+        """
+        Add a torrent to the rTorrent client and return the torrent object.
+
+        :param indexer_result: The indexer query result of the torrent file to download.
+        :return: The torrent object with calculated hash and initial status.
+        """
+        torrent_hash = get_torrent_hash(torrent=indexer_result)
+        download_dir = (
+            MediaManagerConfig().misc.torrent_directory / indexer_result.title
+        )
+        try:
+            # rTorrent fetches the .torrent/magnet from the URL itself, like the
+            # other clients. The empty first argument is the load target.
+            self._engine.rpc.load.start(
+                "",
+                str(indexer_result.download_url),
+                f'd.directory.set="{download_dir}"',
+                f'd.custom1.set="{self.config.label}"',
+            )
+
+            log.info(f"Successfully added torrent to rTorrent: {indexer_result.title}")
+
+        except Exception:
+            log.exception("Failed to add torrent to rTorrent")
+            raise
+
+        torrent = Torrent(
+            status=TorrentStatus.unknown,
+            title=indexer_result.title,
+            quality=indexer_result.quality,
+            imported=False,
+            hash=torrent_hash,
+            usenet=False,
+        )
+
+        torrent.status = self.get_torrent_status(torrent)
+
+        return torrent
+
+    def remove_torrent(self, torrent: Torrent, delete_data: bool = False) -> None:
+        """
+        Remove a torrent from the rTorrent client.
+
+        rTorrent does not delete downloaded files on erase, so when requested the
+        download directory is removed from the (shared) filesystem afterwards.
+
+        :param torrent: The torrent to remove.
+        :param delete_data: Whether to delete the downloaded data.
+        """
+        try:
+            self._engine.rpc.d.erase(torrent.hash.upper())
+        except Exception:
+            log.exception("Failed to remove torrent")
+            raise
+
+        if delete_data:
+            download_dir = get_torrent_filepath(torrent=torrent)
+            try:
+                shutil.rmtree(download_dir)
+            except FileNotFoundError:
+                log.debug(f"Download directory not found, nothing to delete: {download_dir}")
+            except OSError:
+                log.exception(f"Failed to delete download directory: {download_dir}")
+
+    def get_torrent_status(self, torrent: Torrent) -> TorrentStatus:
+        """
+        Get the status of a specific torrent.
+
+        :param torrent: The torrent to get the status of.
+        :return: The status of the torrent.
+        """
+        torrent_hash = torrent.hash.upper()
+        try:
+            # d.complete raises an XML-RPC fault if the hash is unknown to rTorrent
+            try:
+                complete = self._engine.rpc.d.complete(torrent_hash)
+            except Exception:
+                log.warning(f"Torrent not found in rTorrent: {torrent_hash}")
+                return TorrentStatus.unknown
+
+            # Check completion first: a finished torrent must always import, even
+            # if it still carries a benign tracker message.
+            if int(complete) == 1:
+                return TorrentStatus.finished
+
+            message = self._engine.rpc.d.message(torrent_hash)
+            if message and "Tried all trackers" not in message:
+                log.warning(f"Torrent {torrent.title} has error message: {message}")
+                return TorrentStatus.error
+        except Exception:
+            log.exception("Failed to get torrent status")
+            return TorrentStatus.error
+
+        return TorrentStatus.downloading
+
+    def pause_torrent(self, torrent: Torrent) -> None:
+        """
+        Pause a torrent download.
+
+        :param torrent: The torrent to pause.
+        """
+        try:
+            self._engine.rpc.d.pause(torrent.hash.upper())
+            log.debug(f"Successfully paused torrent: {torrent.title}")
+        except Exception:
+            log.exception("Failed to pause torrent")
+            raise
+
+    def resume_torrent(self, torrent: Torrent) -> None:
+        """
+        Resume a torrent download.
+
+        :param torrent: The torrent to resume.
+        """
+        try:
+            self._engine.rpc.d.resume(torrent.hash.upper())
+            log.debug(f"Successfully resumed torrent: {torrent.title}")
+        except Exception:
+            log.exception("Failed to resume torrent")
+            raise

--- a/media_manager/torrent/manager.py
+++ b/media_manager/torrent/manager.py
@@ -7,6 +7,7 @@ from media_manager.torrent.download_clients.abstract_download_client import (
     AbstractDownloadClient,
 )
 from media_manager.torrent.download_clients.qbittorrent import QbittorrentDownloadClient
+from media_manager.torrent.download_clients.rtorrent import RtorrentDownloadClient
 from media_manager.torrent.download_clients.sabnzbd import SabnzbdDownloadClient
 from media_manager.torrent.download_clients.transmission import (
     TransmissionDownloadClient,
@@ -52,6 +53,13 @@ class DownloadManager:
                 self._torrent_client = TransmissionDownloadClient()
             except Exception:
                 log.exception("Failed to initialize Transmission client")
+
+        # If no torrent client is available yet, try rTorrent/ruTorrent
+        if self._torrent_client is None and self.config.rtorrent.enabled:
+            try:
+                self._torrent_client = RtorrentDownloadClient()
+            except Exception:
+                log.exception("Failed to initialize rTorrent client")
 
         # Initialize SABnzbd client for usenet
         if self.config.sabnzbd.enabled:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pillow>=11.3.0",
     "sabnzbd-api>=0.1.2",
     "transmission-rpc>=7.0.11",
+    "pyrosimple>=2.14.2",
     "pathvalidate>=3.3.1",
     "asgi-correlation-id>=4.3.4",
     "torf>=4.3.1",

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bencode-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6f/1fc1f714edc73a9a42af816da2bda82bbcadf1d7f6e6cae854e7087f579b/bencode.py-4.0.0.tar.gz", hash = "sha256:2a24ccda1725a51a650893d0b63260138359eaa299bb6e7a09961350a2a6e05c", size = 19842, upload-time = "2020-06-12T04:34:05.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/9f/eabbc8c8a16db698d9c4bd24953763df2594b054237b89afe1ec56d3965e/bencode.py-4.0.0-py2.py3-none-any.whl", hash = "sha256:99c06a55764e85ffe81622fdf9ee78bd737bad3ea61d119784a54bb28860d962", size = 18975, upload-time = "2020-06-12T04:34:03.759Z" },
+]
+
+[[package]]
 name = "bencoder"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -930,6 +939,15 @@ wheels = [
 ]
 
 [[package]]
+name = "lockfile"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/47/72cb04a58a35ec495f96984dddb48232b551aafb95bde614605b754fe6f7/lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799", size = 20874, upload-time = "2015-11-25T18:29:58.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa", size = 13564, upload-time = "2015-11-25T18:29:51.462Z" },
+]
+
+[[package]]
 name = "makefun"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1045,6 +1063,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings", extra = ["toml"] },
+    { name = "pyrosimple" },
     { name = "pytest" },
     { name = "python-json-logger" },
     { name = "qbittorrent-api" },
@@ -1088,6 +1107,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "pydantic-settings", extras = ["toml"], specifier = ">=2.9.1" },
+    { name = "pyrosimple", specifier = ">=2.14.2" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "qbittorrent-api", specifier = ">=2025.5.0" },
@@ -1212,6 +1232,18 @@ wheels = [
 ]
 
 [[package]]
+name = "parsimonious"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/91/abdc50c4ef06fdf8d047f60ee777ca9b2a7885e1a9cea81343fbecda52d7/parsimonious-0.10.0.tar.gz", hash = "sha256:8281600da180ec8ae35427a4ab4f7b82bfec1e3d1e52f80cb60ea82b9512501c", size = 52172, upload-time = "2022-09-03T17:01:17.004Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/0f/c8b64d9b54ea631fcad4e9e3c8dbe8c11bb32a623be94f22974c88e71eaf/parsimonious-0.10.0-py3-none-any.whl", hash = "sha256:982ab435fabe86519b57f6b35610aa4e4e977e9f02a14353edf4bbc75369fc0f", size = 48427, upload-time = "2022-09-03T17:01:13.814Z" },
+]
+
+[[package]]
 name = "pathvalidate"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1294,6 +1326,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/55/9e34c73e1e490b105b4cd13d08497b1f7cb086a260e4161b7b7c2928b196/prometheus_client-0.16.0.tar.gz", hash = "sha256:a03e35b359f14dd1630898543e2120addfdeacd1a6069c1367ae90fd93ad3f48", size = 117546, upload-time = "2023-01-23T22:09:27.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/8e/6a546e439b4366ab9eab0a736876eb1e1916dd93b4a1fa560ef711d24f8c/prometheus_client-0.16.0-py3-none-any.whl", hash = "sha256:0836af6eb2c8f4fed712b2f279f6c0a8bbab29f9f4aa15276b91c7cb0d1616ab", size = 122464, upload-time = "2023-01-23T22:09:24.404Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -1604,6 +1657,27 @@ crypto = [
 ]
 
 [[package]]
+name = "pyrosimple"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bencode-py" },
+    { name = "jinja2" },
+    { name = "parsimonious" },
+    { name = "prometheus-client" },
+    { name = "prompt-toolkit" },
+    { name = "python-box" },
+    { name = "python-daemon" },
+    { name = "requests" },
+    { name = "shtab" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/68/7ab16d97fb333810f9afca59162bac66c5db431595edfdb768ed6db2a0fc/pyrosimple-2.14.2.tar.gz", hash = "sha256:2f7e0152b2db443d77fe41283b206db1ac8df6561b5d224b0f27e79949d4d935", size = 109742, upload-time = "2025-01-02T03:42:40.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/64/c2c6acdb6ea137fa9d4044064b04f63d31466cd0a47e2fc58fb4cef3c76b/pyrosimple-2.14.2-py3-none-any.whl", hash = "sha256:5fd4367f4252777ee4cf6218336498876769058d32205686f557fe6fbdadd48c", size = 126458, upload-time = "2025-01-02T03:42:38.644Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1617,6 +1691,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-box"
+version = "7.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/0f/34e7ee0a72f1464b4c7a2e8bafb389f230477256af586bc82bcfad85295a/python_box-7.4.1.tar.gz", hash = "sha256:e412e36c25fca8223560516d53ef6c7993591c3b0ec8bb4ec582bf7defdd79f0", size = 49859, upload-time = "2026-02-21T16:21:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/e9/48d1b1eb21efc3f82a31b037b6903c9139018f686d96d251faa4cb0d593a/python_box-7.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:85db37b43094bf6c4884b931fb149a7850db5ce331f6e191edf98b453e6cf2d6", size = 1845195, upload-time = "2026-02-21T16:21:46.235Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/48d38c855f277223caf3aa79518476f95abc07f04386940855b7bd3d95f6/python_box-7.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb204822c7638bd2dbed5c55d6ab264c6903c37d18dee5c45bdbda58b2e1e17a", size = 4468245, upload-time = "2026-02-21T16:26:05.701Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1d/7a1e04f37674399e0f3076cfe1fa358f6a51540ae98299a06f2c0424c471/python_box-7.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:615da3fafd41572aec1b905832555c0ea08b6fbc27cc917356e257a9a5721af7", size = 1295564, upload-time = "2026-02-21T16:22:36.547Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a2/771b5e526bba2214ac2d30e321209a66680c40788616a45cf01005e95204/python_box-7.4.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:33c6701faa51fd87f0dcc538873c0fad2b3a1cc3750eab85835cd071cadf1948", size = 1875508, upload-time = "2026-02-21T16:21:37.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/5f/0e7ea7640ba60ff459ce37e340d816ac5e91b7a9a7c3c161f9dabe622be6/python_box-7.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:ae8c540a0457f52350211d24690211251912018e1e0c1857f50792729d6f562c", size = 1314304, upload-time = "2026-02-21T16:22:22.173Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a6/5d3f3abf46b37aa44b1f6788d287c8b4f2319b55013191dddf25b9e6d62c/python_box-7.4.1-py3-none-any.whl", hash = "sha256:a3b0d84d003882fb6abe505b1b883b3a5dcbf226b0fe168d24bc5ff75d9826e5", size = 30402, upload-time = "2026-02-21T16:21:14.78Z" },
+]
+
+[[package]]
+name = "python-daemon"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lockfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/37/4f10e37bdabc058a32989da2daf29e57dc59dbc5395497f3d36d5f5e2694/python_daemon-3.1.2.tar.gz", hash = "sha256:f7b04335adc473de877f5117e26d5f1142f4c9f7cd765408f0877757be5afbf4", size = 71576, upload-time = "2024-12-03T08:41:07.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/3c/b88167e2d6785c0e781ee5d498b07472aeb9b6765da3b19e7cc9e0813841/python_daemon-3.1.2-py3-none-any.whl", hash = "sha256:b906833cef63502994ad48e2eab213259ed9bb18d54fa8774dcba2ff7864cec6", size = 30872, upload-time = "2024-12-03T08:41:03.322Z" },
 ]
 
 [[package]]
@@ -1707,6 +1807,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
 ]
 
 [[package]]
@@ -1931,6 +2103,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shtab"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/7a/7f131b6082d8b592c32e4312d0a6da3d0b28b8f0d305ddd93e49c9d89929/shtab-1.8.0.tar.gz", hash = "sha256:75f16d42178882b7f7126a0c2cb3c848daed2f4f5a276dd1ded75921cc4d073a", size = 46062, upload-time = "2025-11-18T10:57:47.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/e1/202a31727b0d096a04380f78e809074d7a1d0a22d9d5a39fea1d2353fd02/shtab-1.8.0-py3-none-any.whl", hash = "sha256:f0922a82174b4007e06ac0bac4f79abd826c5cca88e201bfd927f889803c571d", size = 14457, upload-time = "2025-11-18T10:57:45.906Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
@@ -2089,6 +2270,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]
@@ -2318,6 +2508,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #464

## Why
Adds rTorrent (commonly used through the ruTorrent web UI) as a torrent
download client, as requested in #464.

## How it works
- New `RtorrentDownloadClient` (`media_manager/torrent/download_clients/rtorrent.py`)
  implements `AbstractDownloadClient` like the existing clients.
- It talks to rTorrent over its **XML-RPC** interface using `pyrosimple`.
  ruTorrent is only a web UI on top of rTorrent, so the client connects to the
  XML-RPC endpoint ruTorrent / the web server exposes (default `/RPC2`).
- New `[torrents.rtorrent]` config section (host, port, path, https_enabled,
  username, password, label). The client is registered in `DownloadManager` as
  a fallback torrent client after qBittorrent and Transmission.
- Torrents are added via `load.start`, setting the download directory and a
  ruTorrent label (`d.custom1`). rTorrent fetches the .torrent/magnet from the
  URL itself, like the other clients.

## Design decisions / trade-offs
- `get_torrent_status` checks `d.complete` **before** `d.message`, so a finished
  torrent always imports even if it still carries a benign tracker message.
- rTorrent never deletes downloaded files on `d.erase`, so `delete_data=True` is
  handled by removing the download directory from the shared filesystem
  (consistent with the other clients' behaviour).
- Infohashes are upper-cased only at RPC call time, since rTorrent identifies
  torrents by upper-case infohash.

## Notes
- Adds `pyrosimple>=2.14.2` (pure-Python deps); `uv.lock` regenerated. No
  Dockerfile change needed.
- Docs and `config.example.toml` updated with the new section.

## Testing
Tested against crazymax/rtorrent-rutorrent with Prowlarr (Nyaa):
RPC connection, DownloadManager client selection, and the full
download → pause → resume → remove cycle. Includes a fix so download
URLs that redirect to a magnet link load correctly (rTorrent can't
follow HTTP→magnet redirects on its own).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rTorrent/ruTorrent as a download client option with full torrent management (add, remove, pause, resume, status).

* **Documentation**
  * Documented rTorrent/ruTorrent configuration including connection, authentication, XML-RPC path, TLS option and custom label.
  * Updated example configuration with an rTorrent settings template for user reference.

* **Chores**
  * Reduced noisy log output from the rTorrent integration by raising its logger level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->